### PR TITLE
chore(standard-competitive): upgrade cpu and memory to 2core/4gb

### DIFF
--- a/config/default.json
+++ b/config/default.json
@@ -24,10 +24,10 @@
     "variants": {
         "standard-competitive": {
             "image": "sonikro/tf2-standard-competitive:latest",
-            "cpu": 1024,
-            "memory": 2048,
+            "cpu": 2048,
+            "memory": 4096,
             "maxPlayers": 24,
-            "map": "cp_badlands",
+            "map": "cp_process_f12",
             "svPure": 2,
             "defaultCfgs": {
                 "5cp": "fbtf_6v6_5cp.cfg",


### PR DESCRIPTION
After testing a 6v6 match with 1 core and 2 memory ram, I measure average of 80% CPU usage and 90% memory usage. Some players complained about spikes, so I'm increasing the hardware for that type of server. Passtime seems fine, with 1 core/2gb, since it has less players