### PR TITLE
feat(fat-image): adds fat image with baked-in maps

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,5 +1,4 @@
 node_modules/
-maps/
 cdk.out/
 coverage/
 dist/

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -51,6 +51,27 @@ services:
       - "pass_stadium_rc3a"
     profiles:
       - passtime
+  tf2-fat-standard-competitive:
+    build:
+      context: ./
+      dockerfile: ./variants/fat-standard-competitive/Dockerfile
+    ports:
+      - 27015:27015
+      - 27015:27015/udp
+      - 27020:27020
+      - 27020:27020/udp
+    env_file:
+      - .env
+    command:
+      - "-enablefakeip"
+      - "+sv_pure"
+      - "2"
+      - "+maxplayers"
+      - "24"
+      - "+map"
+      - "cp_badlands"
+    profiles:
+      - server
 
 volumes:
   db:

--- a/variants/fat-standard-competitive/Dockerfile
+++ b/variants/fat-standard-competitive/Dockerfile
@@ -1,0 +1,5 @@
+FROM scratch AS maps
+COPY ./maps /maps
+
+FROM sonikro/tf2-standard-competitive:latest
+COPY --from=maps --chown=tf2:tf2 /maps /home/tf2/server/tf/maps

--- a/variants/standard-competitive/Dockerfile
+++ b/variants/standard-competitive/Dockerfile
@@ -11,5 +11,6 @@ USER tf2
 
 COPY --chown=tf2:tf2 ./tf/addons/sourcemod/configs/admins_simple.ini $SERVER_DIR/tf/addons/sourcemod/configs/admins_simple.ini
 
+RUN wget -O /home/tf2/server/tf/addons/sourcemod/plugins/mapdownloader.smx https://github.com/spiretf/mapdownloader/raw/refs/heads/master/plugin/mapdownloader.smx
 COPY --chown=tf2:tf2 custom_entrypoint.sh .
 ENTRYPOINT [ "./custom_entrypoint.sh" ]


### PR DESCRIPTION
Fat image is to be used with Oracle Container Instances, since they don't accept NFS in containers yet