### PR TITLE
Create set-user-data command and start using user preferences to set Steam ID

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,10 +45,11 @@
 
 | Command | Description |
 |--------|-------------|
-| `/create-server <region> <variant> <steam_id>` | Launches a server in the selected region |
+| `/create-server <region> <variant>` | Launches a server in the selected region |
 | `/terminate-server <server_id> <region>` | Terminates a running TF2 server |
-| `/get-balance` | Shows your available credits |
+| `/get-balance` | Shows your available credits (Only enabled if credits are enabled) |
 | `/buy-credits` | *(Coming soon!)* Purchase credits |
+| `/set-user-data <steamId>` | Sets the SteamID of the user, assigning them as the Sourcemod admin for all servers the user creates |
 
 > 💡 *Empty servers are terminated after 10 minutes of inactivity.*
 
@@ -57,6 +58,7 @@
 ## 🎮 Server Variants
 
 - **`standard-competitive`** – Competitive config with logs.tf, demos.tf, and support for 6v6, 9v9, ultiduo
+- **`passtime`** - 12 slots, Passtime enabled server
 
 ---
 

--- a/migrations/20250427161944_user_table.ts
+++ b/migrations/20250427161944_user_table.ts
@@ -1,0 +1,15 @@
+import type { Knex } from "knex";
+
+
+export async function up(knex: Knex): Promise<void> {
+    await knex.schema.createTable("user", (table) => {
+        table.string("id").primary();
+        table.string("steamIdText").nullable();
+    });
+}
+
+
+export async function down(knex: Knex): Promise<void> {
+    await knex.schema.dropTableIfExists("user");
+}
+

--- a/src/core/domain/User.ts
+++ b/src/core/domain/User.ts
@@ -1,0 +1,4 @@
+export interface User {
+    id: string;
+    steamIdText: string;
+}

--- a/src/core/repository/UserRepository.ts
+++ b/src/core/repository/UserRepository.ts
@@ -1,0 +1,6 @@
+import { User } from "../domain/User";
+
+export interface UserRepository {
+    getById(id: string): Promise<User | null>;
+    upsert(user: User): Promise<void>;
+}

--- a/src/core/usecase/SetUserData.test.ts
+++ b/src/core/usecase/SetUserData.test.ts
@@ -1,0 +1,51 @@
+import { Chance } from "chance";
+import { describe, expect, it } from "vitest";
+import { mock } from "vitest-mock-extended";
+import { User } from "../domain/User";
+import { UserError } from "../errors/UserError";
+import { UserRepository } from "../repository/UserRepository";
+import { SetUserData } from "./SetUserData";
+
+describe("SetUserData", () => {
+
+    const chance = new Chance();
+
+    const createTestEnvironment = () => {
+
+        const userRepository = mock<UserRepository>();
+        const user = mock<User>();
+        return {
+            sut: new SetUserData({
+                userRepository
+            }),
+            inputs: {
+                user
+            },
+            dependencies: {
+                userRepository
+            }
+        }
+    }
+
+    it("should validate the Steam ID Format", async () => {
+        // Given
+        const { sut, inputs } = createTestEnvironment();
+        inputs.user.steamIdText = chance.string({ length: 20 });
+        // When / Then
+        expect(sut.execute({
+            user: inputs.user
+        })).rejects.toThrow(new UserError("Invalid Steam ID format. Expected format: STEAM_X:Y:Z"));
+    })
+
+    it("should persist the user data when steam id is valid", async () => {
+        // Given
+        const { sut, inputs, dependencies } = createTestEnvironment();
+        inputs.user.steamIdText = "STEAM_0:1:12345678";
+        // When
+        await sut.execute({
+            user: inputs.user
+        });
+        // Then
+        expect(dependencies.userRepository.upsert).toHaveBeenCalledWith(inputs.user);
+    })
+})

--- a/src/core/usecase/SetUserData.ts
+++ b/src/core/usecase/SetUserData.ts
@@ -1,0 +1,21 @@
+import { User } from "../domain/User";
+import { UserError } from "../errors/UserError";
+import { UserRepository } from "../repository/UserRepository";
+
+export class SetUserData {
+    constructor(
+        private readonly dependencies: {userRepository: UserRepository},
+    ) {}
+
+    async execute(args: {user: User}): Promise<void> {
+        const { userRepository } = this.dependencies;
+        const { user } = args;
+
+        // Validate the Steam ID format
+        const steamIdRegex = /^STEAM_[01]:[01]:\d+$/;
+        if (!steamIdRegex.test(user.steamIdText)) {
+            throw new UserError("Invalid Steam ID format. Expected format: STEAM_X:Y:Z");
+        }
+        await userRepository.upsert(user);
+    }
+}

--- a/src/entrypoints/commands/CreateServer/definition.ts
+++ b/src/entrypoints/commands/CreateServer/definition.ts
@@ -24,8 +24,3 @@ export const createServerCommandDefinition = new SlashCommandBuilder()
             ])
             .setRequired(true)
     )
-    .addStringOption(option =>
-        option.setName('admin_steam_id')
-            .setDescription('Steam ID of the SourceMod Admin to be added to the server. Use the format STEAM_0:1:12345678')
-            .setRequired(false)
-    )

--- a/src/entrypoints/commands/CreateServer/handler.ts
+++ b/src/entrypoints/commands/CreateServer/handler.ts
@@ -9,7 +9,6 @@ export function createServerCommandHandlerFactory(dependencies: {
         const { createServerForUser } = dependencies;
         const region = interaction.options.getString('region') as Region;
         const variantName = interaction.options.getString('variant_name') as Variant;
-        const adminSteamId = interaction.options.getString('admin_steam_id');
 
         await interaction.deferReply({ flags: MessageFlags.Ephemeral });
         // Create server
@@ -23,7 +22,6 @@ export function createServerCommandHandlerFactory(dependencies: {
                 region: region,
                 variantName: variantName!,
                 creatorId: interaction.user.id,
-                adminSteamId: adminSteamId!
             });
 
             await interaction.followUp({

--- a/src/entrypoints/commands/SetUserData/definition.ts
+++ b/src/entrypoints/commands/SetUserData/definition.ts
@@ -1,0 +1,10 @@
+import { SlashCommandBuilder } from "discord.js";
+
+export const setUserDataDefinition = new SlashCommandBuilder()
+    .setName('set-user-data')
+    .setDescription('Sets user specific data')
+    .addStringOption(option =>
+        option.setName('steam_id_text')
+            .setDescription('Steam ID in format STEAM_0:1:12345678')
+            .setRequired(true)
+    )

--- a/src/entrypoints/commands/SetUserData/handler.test.ts
+++ b/src/entrypoints/commands/SetUserData/handler.test.ts
@@ -1,0 +1,63 @@
+import { Chance } from "chance";
+import { ChatInputCommandInteraction, MessageFlags } from "discord.js";
+import { describe, expect, it } from "vitest";
+import { mock } from "vitest-mock-extended";
+import { when } from "vitest-when";
+import { SetUserData } from "../../../core/usecase/SetUserData";
+import { setUserDataHandlerFactory } from "./handler";
+
+describe("setUserDataCommandHandler", () => {
+  const chance = new Chance();
+
+  const createHandler = () => {
+    const setUserData = mock<SetUserData>();
+    const interaction = mock<ChatInputCommandInteraction>();
+    interaction.options = mock();
+
+    const handler = setUserDataHandlerFactory({
+      setUserData,
+    });
+
+    return {
+      setUserData,
+      interaction,
+      handler,
+    };
+  };
+
+  it("should set user data with the specified steamIdText", async () => {
+    // Given
+    const { handler, interaction, setUserData } = createHandler();
+    const steamIdText = chance.string({ length: 17, pool: "0123456789" });
+
+    interaction.user = mock();
+    interaction.user.id = chance.guid();
+    when(interaction.options.getString)
+      .calledWith("steam_id_text")
+      .thenReturn(steamIdText);
+
+    when(setUserData.execute)
+      .calledWith({
+        user: {
+          id: interaction.user.id,
+          steamIdText,
+        },
+      })
+      .thenResolve();
+
+    // When
+    await handler(interaction);
+
+    // Then
+    expect(setUserData.execute).toHaveBeenCalledWith({
+      user: {
+        id: interaction.user.id,
+        steamIdText,
+      },
+    });
+    expect(interaction.reply).toHaveBeenCalledWith({
+      content: `Your user data has been set successfully!`,
+      flags: MessageFlags.Ephemeral,
+    });
+  });
+});

--- a/src/entrypoints/commands/SetUserData/handler.ts
+++ b/src/entrypoints/commands/SetUserData/handler.ts
@@ -1,0 +1,24 @@
+import { ChatInputCommandInteraction, MessageFlags } from "discord.js";
+import { SetUserData } from "../../../core/usecase/SetUserData";
+
+export function setUserDataHandlerFactory(dependencies: {
+    setUserData: SetUserData
+}) {
+    return async function createServerCommandHandler(interaction: ChatInputCommandInteraction) {
+        const { setUserData } = dependencies;
+        const steamId = interaction.options.getString('steam_id_text');
+
+        await setUserData.execute({
+            user: {
+                id: interaction.user.id,
+                steamIdText: steamId!
+            }
+        })
+
+        await interaction.reply({
+            content: `Your user data has been set successfully!`,
+            flags: MessageFlags.Ephemeral
+        });
+
+    }
+}

--- a/src/entrypoints/commands/SetUserData/index.ts
+++ b/src/entrypoints/commands/SetUserData/index.ts
@@ -1,0 +1,2 @@
+export * from "./definition";
+export * from "./handler";

--- a/src/entrypoints/commands/index.ts
+++ b/src/entrypoints/commands/index.ts
@@ -8,6 +8,8 @@ import { getBalanceCommandDefinition } from "./GetBalance/definition";
 import { createGetBalanceCommandHandlerFactory } from "./GetBalance/handler";
 import { terminateServerCommandDefinition, terminateServerHandlerFactory } from "./TerminateServer";
 import { ConfigManager } from "../../core/utils/ConfigManager";
+import { setUserDataDefinition, setUserDataHandlerFactory } from "./SetUserData";
+import { SetUserData } from "../../core/usecase/SetUserData";
 
 export type CommandDependencies = {
     createServerForUser: CreateServerForUser;
@@ -15,6 +17,7 @@ export type CommandDependencies = {
     userCreditsRepository: UserCreditsRepository;
     createCreditsPurchaseOrder: CreateCreditsPurchaseOrder;
     configManager: ConfigManager;
+    setUserData: SetUserData;
 }
 
 export function createCommands(dependencies: CommandDependencies) {
@@ -32,6 +35,13 @@ export function createCommands(dependencies: CommandDependencies) {
             handler: terminateServerHandlerFactory({
                 deleteServerForUser: dependencies.deleteServerForUser,
             }),
+        },
+        setUserData: {
+            name: "set-user-data",
+            definition: setUserDataDefinition,
+            handler: setUserDataHandlerFactory({
+                setUserData: dependencies.setUserData,
+            })
         },
         ...(dependencies.configManager.getCreditsConfig().enabled ? {
             getBalance: {

--- a/src/entrypoints/discordBot.ts
+++ b/src/entrypoints/discordBot.ts
@@ -99,7 +99,8 @@ export async function startDiscordBot() {
             serverRepository,
             userCreditsRepository,
             eventLogger,
-            configManager: defaultConfigManager
+            configManager: defaultConfigManager,
+            userRepository
         }),
         deleteServerForUser: new DeleteServerForUser({
             serverManager: ociServerManager,

--- a/src/entrypoints/discordBot.ts
+++ b/src/entrypoints/discordBot.ts
@@ -23,6 +23,8 @@ import { createCommands } from "./commands";
 import { initializeExpress } from "./http/express";
 import { scheduleConsumeCreditsRoutine, scheduleServerCleanupRoutine } from "./jobs";
 import { scheduleTerminateServersWithoutCreditRoutine } from "./jobs/TerminateServersWithoutCreditRoutine";
+import { SetUserData } from "../core/usecase/SetUserData";
+import { SQliteUserRepository } from "../providers/repository/SQliteUserRepository";
 
 export async function startDiscordBot() {
 
@@ -70,6 +72,9 @@ export async function startDiscordBot() {
     const userCreditsRepository = new SQliteUserCreditsRepository({
         knex: KnexConnectionManager.client
     })
+    const userRepository = new SQliteUserRepository({
+        knex: KnexConnectionManager.client
+    })
 
     const paypalPaymentService = new PaypalPaymentService({
         clientId: process.env.PAYPAL_CLIENT_ID!,
@@ -105,6 +110,9 @@ export async function startDiscordBot() {
             creditOrdersRepository,
             paymentService: adyenPaymentService,
             eventLogger
+        }),
+        setUserData: new SetUserData({
+            userRepository
         }),
         userCreditsRepository,
         configManager: defaultConfigManager

--- a/src/providers/repository/SQliteUserRepository.ts
+++ b/src/providers/repository/SQliteUserRepository.ts
@@ -1,0 +1,27 @@
+import { Knex } from "knex";
+import { UserRepository } from "../../core/repository/UserRepository";
+import { User } from "../../core/domain/User";
+
+export class SQliteUserRepository implements UserRepository {
+
+    constructor(private readonly dependencies: {
+        knex: Knex
+    }){}
+
+    async getById(id: string): Promise<User | null> {
+        const { knex } = this.dependencies;
+        const user = await knex("user").where({ id }).first();
+        if (!user) {
+            return null;
+        }
+        return {
+            id: user.id,
+            steamIdText: user.steamIdText
+        };
+    }
+
+    async upsert(user: User): Promise<void> {
+        const { knex } = this.dependencies;
+        await knex("user").insert(user).onConflict("id").merge();
+    }
+}


### PR DESCRIPTION
Having to specify your SteamID on every new server was annoying, since this information doesn't change, just set it once before using the bot then the bot will know your steam id for the next servers you create.