### PR TITLE
feat(terminateServers): refactors terminate-servers command to not require input

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@
 | Command | Description |
 |--------|-------------|
 | `/create-server <region> <variant>` | Launches a server in the selected region |
-| `/terminate-server <server_id> <region>` | Terminates a running TF2 server |
+| `/terminate-servers` | Terminates all servers created by the user |
 | `/get-balance` | Shows your available credits (Only enabled if credits are enabled) |
 | `/buy-credits` | *(Coming soon!)* Purchase credits |
 | `/set-user-data <steamId>` | Sets the SteamID of the user, assigning them as the Sourcemod admin for all servers the user creates |

--- a/src/entrypoints/commands/TerminateServer/definition.ts
+++ b/src/entrypoints/commands/TerminateServer/definition.ts
@@ -1,20 +1,6 @@
 import { SlashCommandBuilder } from "discord.js";
-import { getRegions, getRegionDisplayName } from "../../../core/domain";
 
 export const terminateServerCommandDefinition = new SlashCommandBuilder()
-    .setName('terminate-server')
-    .setDescription('Shuts down a specified TF2 server')
-    .addStringOption(option =>
-        option.setName('server_id')
-            .setDescription('ID of the server to terminate')
-            .setRequired(true)
-    )
-    .addStringOption(option =>
-        option.setName('region')
-            .setDescription('Region of the server to terminate')
-            .setRequired(true)
-            .setChoices(getRegions().map(region => ({
-                name: getRegionDisplayName(region),
-                value: region
-            })))
-    )
+    .setName('terminate-servers')
+    .setDescription('Shuts down all TF2 servers created by you.')
+    

--- a/src/entrypoints/commands/TerminateServer/handler.ts
+++ b/src/entrypoints/commands/TerminateServer/handler.ts
@@ -1,23 +1,18 @@
 import { ChatInputCommandInteraction, MessageFlags } from "discord.js";
-import { Region } from "../../../core/domain";
 import { DeleteServerForUser } from "../../../core/usecase/DeleteServerForUser";
 
 export function terminateServerHandlerFactory(dependencies: {
     deleteServerForUser: DeleteServerForUser
 }) {
     return async function terminateServerCommandHandler(interaction: ChatInputCommandInteraction) {
-        const serverId = interaction.options.getString('server_id');
-        const region = interaction.options.getString('region');
         const userId = interaction.user.id;
         const { deleteServerForUser } = dependencies;
         await deleteServerForUser.execute({
-            region: region as Region,
-            serverId: serverId!,
             userId: userId,
         })
 
         await interaction.reply({
-            content: `Server has been terminated.`,
+            content: `All servers created by you have been terminated.`,
             flags: MessageFlags.Ephemeral
         });
     }

--- a/src/entrypoints/commands/index.ts
+++ b/src/entrypoints/commands/index.ts
@@ -30,7 +30,7 @@ export function createCommands(dependencies: CommandDependencies) {
             }),
         },
         terminateServer: {
-            name: "terminate-server",
+            name: "terminate-servers",
             definition: terminateServerCommandDefinition,
             handler: terminateServerHandlerFactory({
                 deleteServerForUser: dependencies.deleteServerForUser,


### PR DESCRIPTION
Stop asking for user input, read all servers from the user and terminate them (easier to use than to having to know the ID)