### PR TITLE
Refactor admin list

### DIFF
--- a/config/default.json
+++ b/config/default.json
@@ -50,7 +50,21 @@
                 "koth": "fbtf_6v6_koth.cfg",
                 "pl": "rgl_HL_stopwatch.cfg",
                 "ultiduo": "rgl_ud_ultiduo.cfg"
-            }
+            },
+            "admins": [
+                "STEAM_0:1:124066436", 
+                "STEAM_0:0:674555708", 
+                "STEAM_0:0:29546995", 
+                "STEAM_0:0:126279196", 
+                "STEAM_0:0:43847245", 
+                "STEAM_0:1:609890121", 
+                "STEAM_0:1:79034295", 
+                "STEAM_0:1:80160413", 
+                "STEAM_0:0:559647877",
+                "STEAM_0:1:66778305",
+                "STEAM_0:1:153691324",
+                "STEAM_0:1:569914170"
+            ]
         }
     },
     "discord": {

--- a/src/core/domain/Variant.ts
+++ b/src/core/domain/Variant.ts
@@ -20,6 +20,7 @@ export type VariantConfig = {
         "pl": string;
         "ultiduo": string;
     };
+    admins?: string[];
 }
 
 export function isValidVariant(variant: string): variant is Variant {

--- a/src/providers/services/OCIServerManager.test.ts
+++ b/src/providers/services/OCIServerManager.test.ts
@@ -32,6 +32,9 @@ function createTestEnvironment() {
     maxPlayers: 24,
     map: "ctf_2fort",
     serverName: "Test Server",
+    admins: [
+      "default_admin"
+    ]
   };
 
   const regionConfig: RegionConfig = {
@@ -201,7 +204,7 @@ edicts  : 426 used of 2048 max
                 RCON_PASSWORD: "test-password",
                 STV_NAME: "Test STV",
                 STV_PASSWORD: "test-password",
-                ADMIN_LIST: "12345678901234567",
+                ADMIN_LIST: "default_admin,12345678901234567",
               },
             },
           ],

--- a/src/providers/services/OCIServerManager.test.ts
+++ b/src/providers/services/OCIServerManager.test.ts
@@ -201,7 +201,7 @@ edicts  : 426 used of 2048 max
                 RCON_PASSWORD: "test-password",
                 STV_NAME: "Test STV",
                 STV_PASSWORD: "test-password",
-                ADMIN_STEAM_ID: "12345678901234567",
+                ADMIN_LIST: "12345678901234567",
               },
             },
           ],

--- a/src/providers/services/OCIServerManager.ts
+++ b/src/providers/services/OCIServerManager.ts
@@ -56,7 +56,7 @@ export class OCIServerManager implements ServerManager {
             RCON_PASSWORD: rconPassword,
             STV_NAME: regionConfig.tvHostname,
             STV_PASSWORD: tvPassword,
-            ADMIN_STEAM_ID: sourcemodAdminSteamId || "",
+            ADMIN_LIST: sourcemodAdminSteamId || "",
             ...Object.assign({}, ...defaultCfgsEnvironment),
         };
 

--- a/src/providers/services/OCIServerManager.ts
+++ b/src/providers/services/OCIServerManager.ts
@@ -48,6 +48,14 @@ export class OCIServerManager implements ServerManager {
             }))
             : [];
 
+        const adminList = variantConfig.admins || [];
+
+        // Makes sure the sourcemodAdminSteamId is in the admin list
+        if (sourcemodAdminSteamId) {
+            if (!adminList.includes(sourcemodAdminSteamId)) {
+                adminList.push(sourcemodAdminSteamId);
+            }
+        }
         const environmentVariables: Record<string, string> = {
             SERVER_HOSTNAME: regionConfig.srcdsHostname,
             SERVER_PASSWORD: serverPassword,
@@ -56,7 +64,7 @@ export class OCIServerManager implements ServerManager {
             RCON_PASSWORD: rconPassword,
             STV_NAME: regionConfig.tvHostname,
             STV_PASSWORD: tvPassword,
-            ADMIN_LIST: sourcemodAdminSteamId || "",
+            ADMIN_LIST: adminList.join(","),
             ...Object.assign({}, ...defaultCfgsEnvironment),
         };
 

--- a/variants/standard-competitive/Dockerfile
+++ b/variants/standard-competitive/Dockerfile
@@ -1,6 +1,7 @@
 FROM ghcr.io/melkortf/tf2-competitive:latest
 
-ENV ADMIN_STEAM_ID=""
+# Comma-separated list of Steam IDs for admins
+ENV ADMIN_LIST=""
 ENV DEFAULT_5CP_CFG=""
 ENV DEFAULT_KOTH_CFG=""
 ENV DEFAULT_PL_CFG=""
@@ -9,9 +10,6 @@ ENV DEFAULT_PASSTIME_CFG="pt_global_pug.cfg"
 ENV DEFAULT_TFDB_CFG="dodgeball.cfg"
 
 USER tf2
-
-# Setup admins_simple with variable interpolation
-COPY --chown=tf2:tf2 ./tf/addons/sourcemod/configs/admins_simple.ini $SERVER_DIR/tf/addons/sourcemod/configs/admins_simple.ini
 
 # Installs MapDownloader plugin
 # This plugin allows you to download maps from the server

--- a/variants/standard-competitive/README.md
+++ b/variants/standard-competitive/README.md
@@ -29,7 +29,7 @@ This image is intended to be used as part of the TF2-QuickServer orchestration s
 
 This image supports the following environment variables for customization:
 
-- `ADMIN_STEAM_ID`: Set this to the Steam ID of a player to grant them Sourcemod admin privileges.
+- `ADMIN_LIST`: Comma-separated list of steam ids. Set this to set the Sourcemod admins.
 - `DEFAULT_5CP_CFG`: Specify the configuration file to be executed automatically for 5CP maps.
 - `DEFAULT_PL_CFG`: Specify the configuration file to be executed automatically for Payload (PL) maps.
 - `DEFAULT_KOTH_CFG`: Specify the configuration file to be executed automatically for King of the Hill (KOTH) maps.

--- a/variants/standard-competitive/custom_entrypoint.sh
+++ b/variants/standard-competitive/custom_entrypoint.sh
@@ -3,9 +3,18 @@
 # Runs our custom script
 echo "Running custom entrypoint script..."
 
-# Apply envsubsts to the admins_simple.ini file
-envsubst < "$SERVER_DIR/tf/addons/sourcemod/configs/admins_simple.ini" > "$SERVER_DIR/tf/addons/sourcemod/configs/admins_simple.ini.tmp" && \
-mv "$SERVER_DIR/tf/addons/sourcemod/configs/admins_simple.ini.tmp" "$SERVER_DIR/tf/addons/sourcemod/configs/admins_simple.ini"
+# Generate the admins_simple.ini file based on the ADMIN_LIST environment variable
+if [ -n "$ADMIN_LIST" ]; then
+    echo "Generating admins_simple.ini from ADMIN_LIST..."
+    echo "" > "$SERVER_DIR/tf/addons/sourcemod/configs/admins_simple.ini" # Clear the file
+    IFS=',' read -ra STEAM_IDS <<< "$ADMIN_LIST"
+    for steam_id in "${STEAM_IDS[@]}"; do
+        echo "\"$steam_id\"    \"z\"" >> "$SERVER_DIR/tf/addons/sourcemod/configs/admins_simple.ini"
+        echo "Added $steam_id to admins_simple.ini"
+    done
+else
+    echo "ADMIN_LIST is empty or not set. Skipping admins_simple.ini generation."
+fi
 
 # Generate the adminmenu_cfgs.txt file
 # Cleanup the adminmenu_cfgs.txt file if it exists

--- a/variants/standard-competitive/tf/addons/sourcemod/configs/admins_simple.ini
+++ b/variants/standard-competitive/tf/addons/sourcemod/configs/admins_simple.ini
@@ -1,1 +1,0 @@
-"$ADMIN_STEAM_ID" "99:z" 


### PR DESCRIPTION
- Removes single string of STEAM_ADMIN_ID to receive a list of steam admins
- Allows Variants to specify default admins (useful for variants designed for specific communities)