### PR TITLE
feat(guildParameters): allows guilds to have their own environment variables

### DIFF
--- a/config/default.json
+++ b/config/default.json
@@ -61,6 +61,10 @@
                 "STEAM_0:1:153691324",
                 "STEAM_0:1:569914170"
             ]
+        },
+        "tf2pickup": {
+            "hostname": "tf2pickup.org | {region} @ Sonikro Solutions",
+            "image": "sonikro/fat-tf2pickup:latest"
         }
     },
     "discord": {

--- a/migrations/20250522223242_guild_parameters.ts
+++ b/migrations/20250522223242_guild_parameters.ts
@@ -1,0 +1,15 @@
+import type { Knex } from "knex";
+
+
+export async function up(knex: Knex): Promise<void> {
+    await knex.schema.createTable("guild_parameters", (table) => {
+        table.string("guild_id").primary();
+        table.json("environment_variables").nullable();
+    });
+}
+
+
+export async function down(knex: Knex): Promise<void> {
+    await knex.schema.dropTableIfExists("guild_parameters");
+}
+

--- a/src/core/domain/GuildParameters.ts
+++ b/src/core/domain/GuildParameters.ts
@@ -1,0 +1,4 @@
+export type GuildParameters = {
+    guild_id: string;
+    environment_variables: Record<string, string> | null;
+}

--- a/src/core/domain/Variant.ts
+++ b/src/core/domain/Variant.ts
@@ -2,7 +2,8 @@ import config from "config";
 
 export enum Variant {
     StandardCompetitive = "standard-competitive",
-    InsertCoin = "insertcoin"
+    InsertCoin = "insertcoin",
+    Tf2Pickup = "tf2pickup"
 }
 
 export type VariantConfig = {

--- a/src/core/repository/GuildParametersRepository.ts
+++ b/src/core/repository/GuildParametersRepository.ts
@@ -1,0 +1,5 @@
+import { GuildParameters } from "../domain/GuildParameters";
+
+export interface GuildParametersRepository {
+    findById(guildId: string): Promise<GuildParameters | null>;
+}

--- a/src/core/services/ServerManager.ts
+++ b/src/core/services/ServerManager.ts
@@ -1,13 +1,19 @@
-import { Variant, Server, Region} from "../domain";
+import { Variant, Server, Region } from "../domain";
 
 export interface ServerManager {
     /**
      * Deploys a new TF2 server in the selected region with a specific variant.
      */
-    deployServer(args: {serverId: string, region: Region, variantName: Variant, sourcemodAdminSteamId?: string }): Promise<Server>;
+    deployServer(args: {
+        serverId: string,
+        region: Region,
+        variantName: Variant,
+        sourcemodAdminSteamId?: string,
+        extraEnvs?: Record<string, string>,
+    }): Promise<Server>;
 
     /**
      * Deletes an existing TF2 server.
      */
-    deleteServer(args: {serverId: string, region: Region}): Promise<void>;
+    deleteServer(args: { serverId: string, region: Region }): Promise<void>;
 }

--- a/src/entrypoints/commands/CreateServer/handler.ts
+++ b/src/entrypoints/commands/CreateServer/handler.ts
@@ -3,7 +3,7 @@ import { getRegionDisplayName, Region, Variant } from "../../../core/domain";
 import { CreateServerForUser } from "../../../core/usecase/CreateServerForUser";
 
 export function createServerCommandHandlerFactory(dependencies: {
-    createServerForUser: CreateServerForUser
+    createServerForUser: CreateServerForUser,
 }) {
     return async function createServerCommandHandler(interaction: ChatInputCommandInteraction) {
         const { createServerForUser } = dependencies;
@@ -22,7 +22,19 @@ export function createServerCommandHandlerFactory(dependencies: {
                 region: region,
                 variantName: variantName!,
                 creatorId: interaction.user.id,
+                guildId: interaction.guildId!
             });
+
+            if (variantName === "tf2pickup") {
+                await interaction.followUp({
+                    content: `🎉 **Server Created and Registered!** 🎉\n\n` +
+                        `💻 This server was created and registered to the **tf2pickup.org** instance associated with this Discord Guild.\n` +
+                        `🔒 You will not receive the credentials or connect information, as using the server is managed by the **tf2pickup** instance.\n` +
+                        `✅ The server is now **available to be used**!`,
+                    flags: MessageFlags.Ephemeral
+                });
+                return;
+            }
 
             await interaction.followUp({
                 content: `🎉 **Server Created Successfully!** 🎉\n\n` +

--- a/src/entrypoints/discordBot.ts
+++ b/src/entrypoints/discordBot.ts
@@ -25,6 +25,7 @@ import { scheduleConsumeCreditsRoutine, scheduleServerCleanupRoutine } from "./j
 import { scheduleTerminateServersWithoutCreditRoutine } from "./jobs/TerminateServersWithoutCreditRoutine";
 import { SetUserData } from "../core/usecase/SetUserData";
 import { SQliteUserRepository } from "../providers/repository/SQliteUserRepository";
+import { SQliteGuildParametersRepository } from "../providers/repository/SQliteGuildParametersRepository";
 
 export async function startDiscordBot() {
 
@@ -93,6 +94,10 @@ export async function startDiscordBot() {
         knex: KnexConnectionManager.client
     })
 
+    const guildParametersRepository = new SQliteGuildParametersRepository({
+        knex: KnexConnectionManager.client
+    })
+
     const discordCommands = createCommands({
         createServerForUser: new CreateServerForUser({
             serverManager: ociServerManager,
@@ -100,7 +105,8 @@ export async function startDiscordBot() {
             userCreditsRepository,
             eventLogger,
             configManager: defaultConfigManager,
-            userRepository
+            userRepository,
+            guildParametersRepository
         }),
         deleteServerForUser: new DeleteServerForUser({
             serverManager: ociServerManager,

--- a/src/providers/repository/SQliteGuildParametersRepository.ts
+++ b/src/providers/repository/SQliteGuildParametersRepository.ts
@@ -1,0 +1,20 @@
+import { Knex } from "knex";
+import { GuildParameters } from "../../core/domain/GuildParameters";
+import { GuildParametersRepository } from "../../core/repository/GuildParametersRepository";
+
+export class SQliteGuildParametersRepository implements GuildParametersRepository {
+    constructor(private readonly dependencies: { knex: Knex }) {}
+
+    async findById(guildId: string): Promise<GuildParameters | null> {
+        const result = await this.dependencies.knex("guild_parameters")
+            .where({ guild_id: guildId })
+            .first();
+
+        if (!result) return null;
+
+        return {
+            guild_id: result.guild_id,
+            environment_variables: result.environment_variables ? JSON.parse(result.environment_variables) : null,
+        };
+    }
+}

--- a/src/providers/services/OCIServerManager.test.ts
+++ b/src/providers/services/OCIServerManager.test.ts
@@ -279,6 +279,29 @@ describe("OCIServerManager", () => {
     })
   })
 
+  describe("extra vars", () => {
+    it("should include extraEnvs in the container environment variables", async () => {
+      const { sut, containerClient } = createTestEnvironment();
+    
+      await sut.deployServer({
+        region: testRegion,
+        variantName: testVariant,
+        sourcemodAdminSteamId: "12345678901234567",
+        serverId: "test-server-extra-env",
+        extraEnvs: {
+          CUSTOM_ENV_VAR: "custom-value",
+          ANOTHER_VAR: "another-value"
+        }
+      });
+    
+      const containerInstanceRequest = containerClient.createContainerInstance.mock.calls[0][0];
+      const envVars = containerInstanceRequest.createContainerInstanceDetails.containers[0].environmentVariables!;
+    
+      expect(envVars.CUSTOM_ENV_VAR).toBe("custom-value");
+      expect(envVars.ANOTHER_VAR).toBe("another-value");
+    });
+  })
+
   describe("deleteServer", () => {
     const environment = createTestEnvironment();
 

--- a/src/providers/services/OCIServerManager.ts
+++ b/src/providers/services/OCIServerManager.ts
@@ -22,9 +22,10 @@ export class OCIServerManager implements ServerManager {
         region: Region;
         variantName: Variant;
         sourcemodAdminSteamId?: string;
+        extraEnvs?: Record<string, string>;
     }): Promise<Server> {
         const { serverCommander, configManager, passwordGenerator, ociClientFactory } = this.dependencies;
-        const { region, variantName, sourcemodAdminSteamId, serverId } = args;
+        const { region, variantName, sourcemodAdminSteamId, serverId, extraEnvs = {} } = args;
 
         const { containerClient, vncClient } = ociClientFactory(region);
         const variantConfig = configManager.getVariantConfig(variantName);
@@ -68,6 +69,7 @@ export class OCIServerManager implements ServerManager {
             STV_PASSWORD: tvPassword,
             ADMIN_LIST: adminList.join(","),
             ...Object.assign({}, ...defaultCfgsEnvironment),
+            ...extraEnvs,
         };
 
         const containerRequest: containerinstances.requests.CreateContainerInstanceRequest = {


### PR DESCRIPTION
- Adds a new Tf2Pickup Variant for servers that are compatible with tf2pickup.org system
- Adds a new guild_parameters table that allow guilds to have their own special environmeent varibales

The idea is that if I install this bot in a Guild that runs their own TF2PickupOrg instance, we can set the parameters in the database such as

```json
{"TF2PICKUPORG_API_ADDRESS": "https://api.tf2pickup.org", "TF2PICKUPORG_SECRET": "xxxxx"}
```

And when a server is created from that Guild, these variables will be injected in the container, thus, allowing the server to connect to the corresponding TF2Pickuporg instance.

THis also changes the message the user receives to not include any data about the server, since all should be managed by the TF2PickupOrg

![image](https://github.com/user-attachments/assets/c6d39d7d-f550-4b01-b148-f01bae0f8348)
![image](https://github.com/user-attachments/assets/d7b1b1ce-4287-4654-9d32-9a30ebd32fdc)

