### PR TITLE
Enable alpha ddos monitoring

### DIFF
--- a/.github/workflows/publish-variants.yaml
+++ b/.github/workflows/publish-variants.yaml
@@ -82,7 +82,7 @@ jobs:
           file: ./variants/fat-standard-competitive/Dockerfile
 
       - name: Build and push TF2 Pickup Server
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v6 
         with:
           push: ${{ github.event_name == 'push' }}
           tags: |

--- a/.github/workflows/shield.yml
+++ b/.github/workflows/shield.yml
@@ -1,5 +1,5 @@
-name: Test and Build Shield
-
+name: Shield CI/CD
+description: CI/CD pipeline for the TF2 Quickserver Shield service.
 on:
   push:
     paths:
@@ -33,6 +33,7 @@ jobs:
       - name: Build
         run: make build
   publish:
+    needs: test-and-build
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     defaults:

--- a/shield/Dockerfile
+++ b/shield/Dockerfile
@@ -12,7 +12,7 @@ WORKDIR /
 COPY --from=builder /app/shield ./shield
 
 # Environment variables (can be overridden at runtime)
-ENV IFACE=eth0
-ENV MAXBYTES=100000000
+ENV IFACE=
+ENV MAXBYTES=
 
 ENTRYPOINT ["/shield"]

--- a/shield/README.md
+++ b/shield/README.md
@@ -18,8 +18,9 @@ TF2 QuickServer Shield is a lightweight binary that monitors network traffic on 
    ```sh
    ./bin/shield
    ```
-   - `IFACE`: Network interface (default: `eth0`)
-   - `MAXBYTES`: Max bytes/sec before triggering protection (default: `100000000`)
+   - `IFACE`: Network interface (if not set, defaults to the first non-loopback interface)
+   - `MAXBYTES`: Max bytes/sec before triggering protection (default: `100000000`).
+     - Note: Traffic must exceed this value for more than 3 seconds to be considered an attack.
 
    Example:
    ```sh
@@ -28,5 +29,5 @@ TF2 QuickServer Shield is a lightweight binary that monitors network traffic on 
 
 ## How it works
 - Polls the network interface for received bytes.
-- If traffic exceeds the threshold, triggers the handler.
+- If traffic exceeds the threshold for more than 3 seconds, triggers the handler.
 - The handler updates Oracle NSG rules to block new connections, allowing only current players.

--- a/shield/main.go
+++ b/shield/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"net"
 	"os/signal"
 	"syscall"
 
@@ -11,7 +12,10 @@ import (
 )
 
 func main() {
-	iface := config.GetIface()
+	iface, err := config.GetIface(net.Interfaces)
+	if err != nil {
+		panic(err)
+	}
 	maxBytes := config.GetMaxBytes()
 
 	// Create a context that listens for OS signals to gracefully shut down
@@ -24,7 +28,9 @@ func main() {
 		iface,
 		radar.DefaultProcFSFactory,
 		maxBytes,
+		radar.DefaultTresholdTime,
 		shield.OnAttackDetected,
+		radar.DefaulPollInterval,
 	)
 
 	attackRadar.StartMonitoring(ctx)

--- a/shield/pkg/config/env.go
+++ b/shield/pkg/config/env.go
@@ -1,17 +1,34 @@
 package config
 
 import (
+	"errors"
+	"net"
 	"os"
 	"strconv"
 )
 
-// GetIface returns the network interface name from the IFACE environment variable, or "eth0" if not set.
-func GetIface() string {
+// GetNetworkInterfaces is a function that returns a slice of net.Interface and an error.
+type GetNetworkInterfaces func() ([]net.Interface, error)
+
+// ErrNoNonLoopbackInterface is returned when no suitable network interface is found.
+var ErrNoNonLoopbackInterface = errors.New("no non-loopback network interface found")
+
+// GetIface returns the network interface name from the IFACE environment variable, or auto-detects a non-loopback interface if not set.
+func GetIface(getNetworkInterfaces GetNetworkInterfaces) (string, error) {
 	iface := os.Getenv("IFACE")
 	if iface == "" {
-		iface = "eth0"
+		ifaces, err := getNetworkInterfaces()
+		if err != nil {
+			return "", err
+		}
+		for _, i := range ifaces {
+			if (i.Flags&net.FlagLoopback) == 0 && (i.Flags&net.FlagUp) != 0 {
+				return i.Name, nil
+			}
+		}
+		return "", ErrNoNonLoopbackInterface
 	}
-	return iface
+	return iface, nil
 }
 
 // GetMaxBytes returns the max bytes from the MAXBYTES environment variable, or 100000000 if not set or invalid.

--- a/src/providers/services/OCIServerManager.test.ts
+++ b/src/providers/services/OCIServerManager.test.ts
@@ -216,6 +216,13 @@ describe("OCIServerManager", () => {
                 ADMIN_LIST: "default_admin,12345678901234567",
               },
             },
+            {
+              displayName: "shield",
+              imageUrl: "sonikro/tf2-quickserver-shield:latest",
+              environmentVariables: {
+                MAXBYTES: "2000000"
+              }
+            }
           ],
           vnics: [
             {
@@ -279,6 +286,7 @@ describe("OCIServerManager", () => {
                 SERVER_HOSTNAME: `custom-hostname | São Paulo (Brazil) @ TF2-QuickServer`,
               }),
             }),
+            expect.anything(),
           ],
         }),
       }));
@@ -331,6 +339,7 @@ describe("OCIServerManager", () => {
                 ADMIN_LIST: "12345678901234567",
               }),
             }),
+            expect.anything(),
           ],
         }),
       }));

--- a/src/providers/services/OCIServerManager.ts
+++ b/src/providers/services/OCIServerManager.ts
@@ -94,6 +94,13 @@ export class OCIServerManager implements ServerManager {
                         ],
                         environmentVariables,
                     },
+                    {
+                        displayName: "shield",
+                        imageUrl: "sonikro/tf2-quickserver-shield:latest",
+                        environmentVariables: {
+                            MAXBYTES: "2000000"
+                        }
+                    }
                 ],
                 vnics: [
                     {


### PR DESCRIPTION
- Enables Sidecar Shield container to run and monitor TF2 Network Traffic
- Improves Shield to not trigger on Spikes (Must sustain 2000000 bytes for more than 3 seconds)