### PR TITLE
fix(pickup): do not set logsecret for pickup games

### DIFF
--- a/src/providers/services/OCIServerManager.test.ts
+++ b/src/providers/services/OCIServerManager.test.ts
@@ -228,6 +228,28 @@ edicts  : 426 used of 2048 max
 describe("OCIServerManager", () => {
 
   describe("deployServer", () => {
+    it("should not include sv_logsecret in arguments or environment for pickup variants", async () => {
+      const env = createTestEnvironment();
+      const statusUpdater = vi.fn();
+      // Use a variant name containing 'pickup'
+      const pickupVariant = "pickup6s" as Variant;
+      env.configManager.getVariantConfig.mockReturnValue({
+        ...env.variantConfig,
+        map: "cp_badlands",
+      });
+      await env.sut.deployServer({
+        region: testRegion,
+        variantName: pickupVariant,
+        sourcemodAdminSteamId: "12345678901234567",
+        serverId: "test-server-pickup",
+        statusUpdater,
+      });
+      const containerInstanceRequest = env.containerClient.createContainerInstance.mock.calls[0][0];
+      const tf2Container = containerInstanceRequest.createContainerInstanceDetails.containers.find((c: any) => c.displayName === "test-server-pickup");
+      expect(tf2Container).toBeDefined();
+      // Arguments should not include +sv_logsecret
+      expect(tf2Container!.arguments).not.toContain("+sv_logsecret");
+    });
     const environment = createTestEnvironment();
     let result: Awaited<ReturnType<typeof environment.sut.deployServer>>;
 
@@ -293,7 +315,6 @@ describe("OCIServerManager", () => {
                 STV_NAME: "Test STV",
                 STV_PASSWORD: "test-password",
                 ADMIN_LIST: "default_admin,12345678901234567",
-                SV_LOGSECRET: expect.any(String), // This will be set later
               },
             },
             {

--- a/src/providers/services/OCIServerManager.ts
+++ b/src/providers/services/OCIServerManager.ts
@@ -102,6 +102,8 @@ export class OCIServerManager implements ServerManager {
         const adminList = variantConfig.admins ? [...variantConfig.admins, sourcemodAdminSteamId] : [sourcemodAdminSteamId];
 
         const hostname = variantConfig.hostname ? variantConfig.hostname.replace("{region}", getRegionDisplayName(region)) : regionConfig.srcdsHostname;
+        // Determine if this is a pickup variant
+        const isPickupVariant = variantName.toLowerCase().includes("pickup");
         const environmentVariables: Record<string, string> = {
             SERVER_HOSTNAME: hostname,
             SERVER_PASSWORD: serverPassword,
@@ -111,7 +113,6 @@ export class OCIServerManager implements ServerManager {
             STV_NAME: regionConfig.tvHostname,
             STV_PASSWORD: tvPassword,
             ADMIN_LIST: adminList.join(","),
-            SV_LOGSECRET: logSecret.toString(),
             ...Object.assign({}, ...defaultCfgsEnvironment),
             ...extraEnvs,
         };
@@ -152,8 +153,7 @@ export class OCIServerManager implements ServerManager {
                             "on",
                             "+logaddress_add",
                             process.env.SRCDS_LOG_ADDRESS || "",
-                            "+sv_logsecret",
-                            logSecret.toString(),
+                            ...(!isPickupVariant ? ["+sv_logsecret", logSecret.toString()] : []),
                         ],
                         environmentVariables,
                     },

--- a/variants/base/enforced_cvars.cfg
+++ b/variants/base/enforced_cvars.cfg
@@ -5,6 +5,5 @@ mp_idlemaxtime 45
 mp_idledealmethod 2
 mapcyclefile cfg/mapcycle.txt
 supstats_accuracy 1
-sv_logsecret "${SV_LOGSECRET}"
 sv_minrate 20000
 sv_maxrate 0

--- a/variants/base/tf/addons/sourcemod/configs/rcon_blocklist.txt
+++ b/variants/base/tf/addons/sourcemod/configs/rcon_blocklist.txt
@@ -1,2 +1,4 @@
 logaddress_list
 logaddress_delall
+logaddress_add
+logaddress_del

--- a/variants/base/tf/addons/sourcemod/configs/secret_cvars.txt
+++ b/variants/base/tf/addons/sourcemod/configs/secret_cvars.txt
@@ -2,3 +2,4 @@ logstf_apikey
 rcon_password
 sm_demostf_apikey
 sm_tf2pickuporg_secret
+sv_logsecret


### PR DESCRIPTION
The Pickup system will not work properly if we set our own custom logsecret, the pickup system has its own way of setting the logsecret.