### PR TITLE
chore: update server hostname format by removing "@ Sonikro Solutions"  references across configuration and test files

### DIFF
--- a/config/default.json
+++ b/config/default.json
@@ -2,28 +2,28 @@
     "regions": {
         "sa-saopaulo-1": {
             "displayName": "São Paulo (Brazil)",
-            "srcdsHostname": "TF2-QuickServer | São Paulo @ Sonikro Solutions",
-            "tvHostname": "TF2-QuickServer TV | São Paulo @ Sonikro Solutions"
+            "srcdsHostname": "TF2-QuickServer | São Paulo",
+            "tvHostname": "TF2-QuickServer TV | São Paulo"
         },
         "sa-santiago-1": {
             "displayName": "Santiago (Chile)",
-            "srcdsHostname": "TF2-QuickServer | Santiago @ Sonikro Solutions",
-            "tvHostname": "TF2-QuickServer TV | Santiago @ Sonikro Solutions"
+            "srcdsHostname": "TF2-QuickServer | Santiago",
+            "tvHostname": "TF2-QuickServer TV | Santiago"
         },
         "sa-bogota-1": {
             "displayName": "Bogotá (Colombia)",
-            "srcdsHostname": "TF2-QuickServer | Bogotá @ Sonikro Solutions",
-            "tvHostname": "TF2-QuickServer TV | Bogotá @ Sonikro Solutions"
+            "srcdsHostname": "TF2-QuickServer | Bogotá",
+            "tvHostname": "TF2-QuickServer TV | Bogotá"
         },
         "us-chicago-1": {
             "displayName": "Chicago (USA)",
-            "srcdsHostname": "TF2-QuickServer | Chicago @ Sonikro Solutions",
-            "tvHostname": "TF2-QuickServer TV | Chicago @ Sonikro Solutions"
+            "srcdsHostname": "TF2-QuickServer | Chicago",
+            "tvHostname": "TF2-QuickServer TV | Chicago"
         },
         "eu-frankfurt-1": {
             "displayName": "Frankfurt (Germany)",
-            "srcdsHostname": "TF2-QuickServer | Frankfurt @ Sonikro Solutions",
-            "tvHostname": "TF2-QuickServer TV | Frankfurt @ Sonikro Solutions"
+            "srcdsHostname": "TF2-QuickServer | Frankfurt",
+            "tvHostname": "TF2-QuickServer TV | Frankfurt"
         }
     },
     "variants": {
@@ -51,7 +51,7 @@
                 "5cp": "fbtf_6v6_5cp.cfg",
                 "koth": "fbtf_6v6_koth.cfg"
             },
-            "hostname": "FBTF 6v6 Standard | {region} @ Sonikro Solutions",
+            "hostname": "FBTF 6v6 Standard | {region} @ TF2-QuickServer",
             "guildId": "144450745662570496"
         },
         "fbtf-6v6-pro": {
@@ -60,7 +60,7 @@
                 "5cp": "fbtf_6v6_5cp_pro.cfg",
                 "koth": "fbtf_6v6_koth.cfg"
             },
-            "hostname": "FBTF 6v6 Pro | {region} @ Sonikro Solutions",
+            "hostname": "FBTF 6v6 Pro | {region} @ TF2-QuickServer",
             "guildId": "144450745662570496"
         },
         "fbtf-9v9": {
@@ -70,12 +70,12 @@
                 "koth": "rgl_HL_koth.cfg",
                 "cp_steel_f12": "rgl_HL_stopwatch.cfg"
             },
-            "hostname": "FBTF 9v9 | {region} @ Sonikro Solutions",
+            "hostname": "FBTF 9v9 | {region} @ TF2-QuickServer",
             "guildId": "144450745662570496"
         },
         "insertcoin": {
             "displayName": "InsertCoin Mixes",
-            "hostname": "InsertCoin Mixes | {region} @ Sonikro Solutions",
+            "hostname": "InsertCoin Mixes | {region} @ TF2-QuickServer",
             "defaultCfgs": {
                 "5cp": "insertcoin_5cp.cfg",
                 "koth": "fbtf_6v6_koth.cfg",
@@ -102,7 +102,7 @@
         },
         "tf2pickup": {
             "displayName": "br.tf2pickup.org",
-            "hostname": "br.tf2pickup.org | {region} @ Sonikro Solutions",
+            "hostname": "br.tf2pickup.org | {region} @ TF2-QuickServer",
             "image": "sonikro/fat-tf2-pickup:latest",
             "emptyMinutesTerminate": 60,
             "admins": [
@@ -119,7 +119,7 @@
         },
         "hlbr-tf2pickup": {
             "displayName": "hl.br.tf2pickup.org",
-            "hostname": "hl.br.tf2pickup.org | {region} @ Sonikro Solutions",
+            "hostname": "hl.br.tf2pickup.org | {region} @ TF2-QuickServer",
             "image": "sonikro/fat-tf2-pickup:latest",
             "emptyMinutesTerminate": 60,
             "admins": [
@@ -133,7 +133,7 @@
         },
         "mix-sa-novatos": {
             "displayName": "Mix SA Novatos",
-            "hostname": "Mix SA Novatos | {region} @ Sonikro Solutions",
+            "hostname": "Mix SA Novatos | {region} @ TF2-QuickServer",
             "defaultCfgs": {
                 "5cp": "novatos_6v6_5cp.cfg",
                 "koth": "novatos_6v6_koth.cfg"
@@ -150,7 +150,7 @@
         },
         "TFArena": {
             "displayName": "TF Arena",
-            "hostname": "TFArena | {region} @ Sonikro Solutions",
+            "hostname": "TFArena | {region} @ TF2-QuickServer",
             "defaultCfgs": {
                 "5cp": "tfarena_6v6_5cp.cfg",
                 "koth": "tfarena_6v6_koth.cfg",

--- a/scripts/test_image.sh
+++ b/scripts/test_image.sh
@@ -17,7 +17,7 @@ docker run -d --name "$CONTAINER_NAME" \
   -e ADMIN_LIST=STEAM_0:0:14581482 \
   -e RCON_PASSWORD=test \
   -e SRCDS_PASSWORD=test \
-  -e SERVER_HOSTNAME="Test @ Sonikro Solutions" \
+  -e SERVER_HOSTNAME="Test" \
   -e SERVER_PASSWORD=mix \
   -e STV_PASSWORD=tv \
   "$IMAGE_NAME" \

--- a/shield/pkg/srcds/player_ips_test.go
+++ b/shield/pkg/srcds/player_ips_test.go
@@ -13,7 +13,7 @@ func (f *fakeRconConn) Execute(cmd string) (string, error) {
 }
 
 func TestGetPlayerIPs(t *testing.T) {
-	exampleStatus := `hostname: TF2-QuickServer | Virginia @ Sonikro Solutions
+	exampleStatus := `hostname: TF2-QuickServer | Virginia
 version : 9543365/24 9543365 secure
 udp/ip  : 169.254.173.35:13768  (local: 0.0.0.0:27015)  (public IP from Steam: 44.200.128.3)
 steamid : [A:1:1871475725:44792] (90264374594008077)

--- a/src/core/domain/ServerStatus.test.ts
+++ b/src/core/domain/ServerStatus.test.ts
@@ -3,7 +3,7 @@ import { ServerStatus } from "./ServerStatus";
 
 describe("ServerStatus", () => {
 
-    const serverStatusString = `hostname: TF2-QuickServer | Virginia @ Sonikro Solutions
+    const serverStatusString = `hostname: TF2-QuickServer | Virginia
 version : 9543365/24 9543365 secure
 udp/ip  : 169.254.173.35:13768  (local: 0.0.0.0:27015)  (public IP from Steam: 44.200.128.3)
 steamid : [A:1:1871475725:44792] (90264374594008077)

--- a/src/core/usecase/__tests__/mockStatusStrings.ts
+++ b/src/core/usecase/__tests__/mockStatusStrings.ts
@@ -1,4 +1,4 @@
-export const nonEmptyServerStatus = `hostname: TF2-QuickServer | Virginia @ Sonikro Solutions
+export const nonEmptyServerStatus = `hostname: TF2-QuickServer | Virginia
 version : 9543365/24 9543365 secure
 udp/ip  : 169.254.173.35:13768  (local: 0.0.0.0:27015)  (public IP from Steam: 44.200.128.3)
 steamid : [A:1:1871475725:44792] (90264374594008077)
@@ -13,7 +13,7 @@ edicts  : 426 used of 2048 max
 #      3 "sonikro"           [U:1:29162964]      00:20       60    0 active 169.254.249.16:18930
 `
 
-export const emptyServerStatus = `hostname: TF2-QuickServer | Virginia @ Sonikro Solutions
+export const emptyServerStatus = `hostname: TF2-QuickServer | Virginia
 version : 9543365/24 9543365 secure
 udp/ip  : 169.254.173.35:13768  (local: 0.0.0.0:27015)  (public IP from Steam: 44.200.128.3)
 steamid : [A:1:1871475725:44792] (90264374594008077)

--- a/src/providers/services/OCIServerManager.test.ts
+++ b/src/providers/services/OCIServerManager.test.ts
@@ -122,7 +122,7 @@ function createTestEnvironment() {
       port: 27015,
       timeout: 5000,
     })
-    .thenResolve(`hostname: TF2-QuickServer | Virginia @ Sonikro Solutions
+    .thenResolve(`hostname: TF2-QuickServer | Virginia
 version : 9543365/24 9543365 secure
 udp/ip  : 169.254.173.35:13768  (local: 0.0.0.0:27015)  (public IP from Steam: 44.200.128.3)
 steamid : [A:1:1871475725:44792] (90264374594008077)


### PR DESCRIPTION
Start using TF2-QuickServer branding instead of Sonikro Solutions