### PR TITLE
Improve Database consistency with Transactions

### DIFF
--- a/src/core/repository/ServerActivityRepository.ts
+++ b/src/core/repository/ServerActivityRepository.ts
@@ -1,8 +1,10 @@
+import { Knex } from "knex";
 import { ServerActivity } from "../domain/ServerActivity";
 
 export interface ServerActivityRepository {
-    upsert(serverActivity: ServerActivity): Promise<void>;
-    deleteById(serverId: string): Promise<void>;
-    findById(serverId: string): Promise<ServerActivity | null>;
-    getAll(): Promise<ServerActivity[]>;
+    upsert(serverActivity: ServerActivity, trx?: Knex.Transaction): Promise<void>;
+    deleteById(serverId: string, trx?: Knex.Transaction): Promise<void>;
+    findById(serverId: string, trx?: Knex.Transaction): Promise<ServerActivity | null>;
+    getAll(trx?: Knex.Transaction): Promise<ServerActivity[]>;
+    runInTransaction<T>(fn: (trx: Knex.Transaction) => Promise<T>): Promise<T>;
 }

--- a/src/core/repository/ServerRepository.ts
+++ b/src/core/repository/ServerRepository.ts
@@ -4,9 +4,9 @@ import { Server, ServerStatus } from "../domain";
 export interface ServerRepository {
     upsertServer(server: Server, trx?: Knex.Transaction): Promise<void>;
     getAllServersByUserId(userId: string, trx?: Knex.Transaction): Promise<Server[]>;
-    deleteServer(serverId: string): Promise<void>;
-    findById(serverId: string): Promise<Server | null>;
-    getAllServers(status?: ServerStatus): Promise<Server[]>;
+    deleteServer(serverId: string, trx?: Knex.Transaction): Promise<void>;
+    findById(serverId: string, trx?: Knex.Transaction): Promise<Server | null>;
+    getAllServers(status?: ServerStatus, trx?: Knex.Transaction): Promise<Server[]>;
     runInTransaction<T>(fn: (trx: Knex.Transaction) => Promise<T>): Promise<T>;
     findByLogsecret(logsecret: number): Promise<Server | null>;
 }

--- a/src/core/usecase/DeleteServerForUser.ts
+++ b/src/core/usecase/DeleteServerForUser.ts
@@ -1,4 +1,5 @@
 import { UserError } from "../errors/UserError";
+import { ServerActivityRepository } from "../repository/ServerActivityRepository";
 import { ServerRepository } from "../repository/ServerRepository";
 import { EventLogger } from "../services/EventLogger";
 import { ServerAbortManager } from "../services/ServerAbortManager";
@@ -8,6 +9,7 @@ export class DeleteServerForUser {
     constructor(
         private readonly dependencies: {
             serverRepository: ServerRepository;
+            serverActivityRepository: ServerActivityRepository;
             serverManager: ServerManager;
             eventLogger: EventLogger;
             serverAbortManager: ServerAbortManager
@@ -17,46 +19,53 @@ export class DeleteServerForUser {
     async execute(args: {
         userId: string;
     }): Promise<void> {
-        const { serverRepository, serverManager, eventLogger, serverAbortManager } = this.dependencies;
+        const { serverRepository, serverActivityRepository, serverManager, eventLogger, serverAbortManager } = this.dependencies;
         const { userId } = args;
-        const server = await serverRepository.getAllServersByUserId(userId);
-        const pendingServers = server.filter(s => s.status === "pending");
-        if (pendingServers.length > 0) {
-            throw new UserError("You have a server that is still being created. Please wait until it is ready before deleting.");
-        }
+        
+        // Use transaction to ensure consistency
+        await serverRepository.runInTransaction(async (trx) => {
+            const server = await serverRepository.getAllServersByUserId(userId, trx);
+            const pendingServers = server.filter(s => s.status === "pending");
+            if (pendingServers.length > 0) {
+                throw new UserError("You have a server that is still being created. Please wait until it is ready before deleting.");
+            }
 
-        if (!server || server.length === 0) {
-            throw new UserError("You don't have any servers to terminate.");
-        }
+            if (!server || server.length === 0) {
+                throw new UserError("You don't have any servers to terminate.");
+            }
 
-        const settled = await Promise.allSettled(server.map(async (s) => {
-            const { serverId, region } = s;
-            // Perform server-specific cleanup using ServerManager
-            await serverManager.deleteServer({
-                region,
-                serverId
-            });
-            // Delete the server
-            await serverRepository.deleteServer(serverId);
-            const abortController = serverAbortManager.getOrCreate(serverId);
-            // Abort any ongoing operations for this server
-            abortController.abort();
-            // Remove the abort controller from the manager
-            serverAbortManager.delete(serverId);
-            await eventLogger.log({
-                eventMessage: `User deleted server with ID ${serverId} in region ${region}.`,
-                actorId: userId,
-            });
-        }));
+            const settled = await Promise.allSettled(server.map(async (s) => {
+                const { serverId, region } = s;
+                // Perform server-specific cleanup using ServerManager
+                await serverManager.deleteServer({
+                    region,
+                    serverId
+                });
+                // Delete the server and its activity in the same transaction
+                await serverRepository.deleteServer(serverId, trx);
+                // Also delete server activity to prevent orphaned records
+                await serverActivityRepository.deleteById(serverId, trx);
+                
+                const abortController = serverAbortManager.getOrCreate(serverId);
+                // Abort any ongoing operations for this server
+                abortController.abort();
+                // Remove the abort controller from the manager
+                serverAbortManager.delete(serverId);
+                await eventLogger.log({
+                    eventMessage: `User deleted server with ID ${serverId} in region ${region}.`,
+                    actorId: userId,
+                });
+            }));
 
-        const errors = settled.filter(result => result.status === 'rejected');
-        if (errors.length > 0) {
-            const errorMessages = errors.map(error => (error as PromiseRejectedResult).reason.message).join(', ');
-            await eventLogger.log({
-                eventMessage: `Failed to delete some servers: ${errorMessages}`,
-                actorId: userId,
-            })
-            throw new UserError(`Failed to delete some servers, please reach out to support.`)
-        }
+            const errors = settled.filter(result => result.status === 'rejected');
+            if (errors.length > 0) {
+                const errorMessages = errors.map(error => (error as PromiseRejectedResult).reason.message).join(', ');
+                await eventLogger.log({
+                    eventMessage: `Failed to delete some servers: ${errorMessages}`,
+                    actorId: userId,
+                })
+                throw new UserError(`Failed to delete some servers, please reach out to support.`)
+            }
+        });
     }
 }

--- a/src/entrypoints/discordBot.ts
+++ b/src/entrypoints/discordBot.ts
@@ -124,6 +124,7 @@ export async function startDiscordBot() {
         deleteServerForUser: new DeleteServerForUser({
             serverManager: ociServerManager,
             serverRepository,
+            serverActivityRepository,
             eventLogger,
             serverAbortManager
         }),

--- a/src/providers/repository/SQliteServerActivityRepository.ts
+++ b/src/providers/repository/SQliteServerActivityRepository.ts
@@ -3,23 +3,41 @@ import { Knex } from "knex";
 export class SQliteServerActivityRepository {
     constructor(private readonly dependencies: { knex: Knex }) {}
 
-    async upsert(serverActivity: { serverId: string; emptySince: Date | null; lastCheckedAt: Date | null }): Promise<void> {
-        await this.dependencies.knex("server_activity")
+    async upsert(serverActivity: { serverId: string; emptySince: Date | null; lastCheckedAt: Date | null }, trx?: Knex.Transaction): Promise<void> {
+        const query = this.dependencies.knex("server_activity")
             .insert(serverActivity)
             .onConflict("serverId")
             .merge();
+
+        if (trx) {
+            query.transacting(trx);
+        }
+
+        await query;
     }
 
-    async deleteById(serverId: string): Promise<void> {
-        await this.dependencies.knex("server_activity")
+    async deleteById(serverId: string, trx?: Knex.Transaction): Promise<void> {
+        const query = this.dependencies.knex("server_activity")
             .where({ serverId })
             .del();
+
+        if (trx) {
+            query.transacting(trx);
+        }
+
+        await query;
     }
 
-    async findById(serverId: string): Promise<{ serverId: string; emptySince: Date | null; lastCheckedAt: Date | null } | null> {
-        const result = await this.dependencies.knex("server_activity")
+    async findById(serverId: string, trx?: Knex.Transaction): Promise<{ serverId: string; emptySince: Date | null; lastCheckedAt: Date | null } | null> {
+        const query = this.dependencies.knex("server_activity")
             .where({ serverId })
             .first();
+
+        if (trx) {
+            query.transacting(trx);
+        }
+
+        const result = await query;
 
         if (!result) return null;
 
@@ -30,14 +48,24 @@ export class SQliteServerActivityRepository {
         };
     }
 
-    async getAll(): Promise<{ serverId: string; emptySince: Date | null; lastCheckedAt: Date | null }[]> {
-        const results = await this.dependencies.knex("server_activity").select("*");
+    async getAll(trx?: Knex.Transaction): Promise<{ serverId: string; emptySince: Date | null; lastCheckedAt: Date | null }[]> {
+        const query = this.dependencies.knex("server_activity").select("*");
+
+        if (trx) {
+            query.transacting(trx);
+        }
+
+        const results = await query;
 
         return results.map((result) => ({
             serverId: result.serverId,
             emptySince: toDate(result.emptySince),
             lastCheckedAt: toDate(result.lastCheckedAt),
         }));
+    }
+
+    async runInTransaction<T>(fn: (trx: Knex.Transaction) => Promise<T>): Promise<T> {
+        return this.dependencies.knex.transaction(fn);
     }
 }
 

--- a/src/providers/repository/SQliteServerRepository.ts
+++ b/src/providers/repository/SQliteServerRepository.ts
@@ -48,26 +48,41 @@ export class SQLiteServerRepository implements ServerRepository {
         return servers.map(this.deserialize);
     }
 
-    async deleteServer(serverId: string): Promise<void> {
-        await this.dependencies.knex<Server>('servers')
+    async deleteServer(serverId: string, trx?: Knex.Transaction): Promise<void> {
+        const query = this.dependencies.knex<Server>('servers')
             .where({ serverId })
             .del();
+
+        if (trx) {
+            query.transacting(trx);
+        }
+
+        await query;
     }
 
-    async findById(serverId: string): Promise<Server | null> {
-        const server = await this.dependencies.knex<Server>('servers')
+    async findById(serverId: string, trx?: Knex.Transaction): Promise<Server | null> {
+        const query = this.dependencies.knex<Server>('servers')
             .where({ serverId })
             .first();
 
+        if (trx) {
+            query.transacting(trx);
+        }
+
+        const server = await query;
         return server ? this.deserialize(server) : null;
     }
 
-    async getAllServers(status?: ServerStatus): Promise<Server[]> {
+    async getAllServers(status?: ServerStatus, trx?: Knex.Transaction): Promise<Server[]> {
         const query = this.dependencies.knex<Server>('servers')
             .select('*');
 
         if (status) {
             query.where({ status });
+        }
+
+        if (trx) {
+            query.transacting(trx);
         }
 
         const servers = await query;

--- a/src/providers/services/OCIServerManager.test.ts
+++ b/src/providers/services/OCIServerManager.test.ts
@@ -271,7 +271,7 @@ describe("OCIServerManager", () => {
       expect(environment.statusUpdater).toHaveBeenNthCalledWith(1, "🛡️ [1/5] Creating SHIELD Firewall...");
       expect(environment.statusUpdater).toHaveBeenNthCalledWith(2, "📦 [2/5] Creating server instance...");
       expect(environment.statusUpdater).toHaveBeenNthCalledWith(3, "🌐 [3/5] Waiting for Server Network Interfaces to be ready...");
-      expect(environment.statusUpdater).toHaveBeenNthCalledWith(4, "⏳ [4/5] Waiting for server instance to be **ACTIVE**...");
+      expect(environment.statusUpdater).toHaveBeenNthCalledWith(4, "⏳ [4/5] Waiting for server instance to be **ACTIVE**... This usually takes 2-3 minutes.");
       expect(environment.statusUpdater).toHaveBeenNthCalledWith(5, "🔄 [5/5] Waiting for server to be ready to receive RCON commands...");
     });
 

--- a/src/providers/services/OCIServerManager.ts
+++ b/src/providers/services/OCIServerManager.ts
@@ -229,7 +229,7 @@ export class OCIServerManager implements ServerManager {
         }
 
         // Notify user: Waiting for container to be ACTIVE
-        await statusUpdater(`⏳ [4/5] Waiting for server instance to be **ACTIVE**...`);
+        await statusUpdater(`⏳ [4/5] Waiting for server instance to be **ACTIVE**... This usually takes 2-3 minutes.`);
         // Wait for container to be ACTIVE
         await waitUntil(async () => {
             const containerInstance = await containerClient.getContainerInstance({


### PR DESCRIPTION
Sometimes when the CLeanup ROutine was executed at the same time as users manually trying to delete the servers, we would have errors related to database concurrency