### PR TITLE
feat: update server variant filtering for Santiago region to include amd64 images only

### DIFF
--- a/config/default.json
+++ b/config/default.json
@@ -102,6 +102,7 @@
         },
         "insertcoin": {
             "displayName": "InsertCoin Mixes",
+            "image": "sonikro/fat-tf2-standard-competitive-amd64:latest",
             "hostname": "InsertCoin Mixes | {region} @ TF2-QuickServer",
             "defaultCfgs": {
                 "5cp": "insertcoin_5cp.cfg",

--- a/src/entrypoints/commands/CreateServer/handler.test.ts
+++ b/src/entrypoints/commands/CreateServer/handler.test.ts
@@ -266,7 +266,7 @@ describe("createServerCommandHandler", () => {
     });
 
     it("should only show variants with matching guildId or no guildId", async () => {
-        const { handler, interaction, message, collector } = createHandler();
+        const { handler, interaction } = createHandler();
         const region = getTestRegion();
         const guildId = interaction.guildId;
 
@@ -343,28 +343,24 @@ describe("createServerCommandHandler", () => {
 
 
 
-    it("should only show standard-competitive-64bit variant for Santiago region", async () => {
+    it("it should only show 64bit variants for Santiago", async () => {
         const { handler, interaction } = createHandler();
+
+        interaction.guildId = "1323509685264842752" // InsertCoin
 
         when(interaction.options.getString)
             .calledWith("region")
             .thenReturn(Region.SA_SANTIAGO_1);
 
         // Mock admin permissions to bypass the Santiago block
-        const permissions = mock<PermissionsBitField>();
-        when(permissions.has).calledWith(expect.anything()).thenReturn(true);
-        interaction.member = {
-            permissions
-        } as any;
 
         interaction.reply = vi.fn().mockResolvedValue(undefined) as any;
 
         await handler(interaction);
 
-        // Check that only the standard-competitive-64bit variant is shown
         const replyCall = (interaction.reply as any).mock.calls[0][0];
         const displayedVariants = replyCall.components.flatMap((row: any) => row.components.map((btn: any) => btn.data.label));
         
-        expect(displayedVariants).toEqual(['Standard Competitive 64-bit (Experimental)']);
+        expect(displayedVariants).toEqual(['Standard Competitive 64-bit (Experimental)', 'InsertCoin Mixes']);
     });
 });

--- a/src/entrypoints/commands/CreateServer/handler.ts
+++ b/src/entrypoints/commands/CreateServer/handler.ts
@@ -30,16 +30,15 @@ export function createServerCommandHandlerFactory(dependencies: {
                 return false;
             }
 
-            // Special filtering for SA_SANTIAGO_1: only allow standard-competitive-64bit (amd64 version)
-            if (region === Region.SA_SANTIAGO_1) {
-                return variant.name === 'standard-competitive-64bit';
-            }
-
-            // For all other regions: exclude the amd64 variant (standard-competitive-64bit)
-            if (variant.name === 'standard-competitive-64bit') {
+            // Only show amd64  images for Santiago region
+            if (region !== Region.SA_SANTIAGO_1 && variant.config.image.includes("amd64")) {
                 return false;
             }
 
+            // Do not show 32-bit variants in Santiago
+            if (region === Region.SA_SANTIAGO_1 && !variant.config.image.includes("amd64")) {
+                return false;
+            }
             return true;
         });
 


### PR DESCRIPTION
Santiago is the only region right now that only supports 64bit SRCDS, so update filters to reflect that.