### PR TITLE
feat(DeleteServer): implement DeleteServer use case and associated task processor; refactor server deletion logic for user commands

### DIFF
--- a/src/core/usecase/DeleteServer.test.ts
+++ b/src/core/usecase/DeleteServer.test.ts
@@ -1,0 +1,187 @@
+import { Chance } from "chance";
+import { Knex } from "knex";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { mock } from "vitest-mock-extended";
+import { ServerManagerFactory } from "../../providers/services/ServerManagerFactory";
+import { Region, Server } from "../domain";
+import { ServerActivityRepository } from "../repository/ServerActivityRepository";
+import { ServerRepository } from "../repository/ServerRepository";
+import { EventLogger } from "../services/EventLogger";
+import { ServerAbortManager } from "../services/ServerAbortManager";
+import { ServerManager } from "../services/ServerManager";
+import { DeleteServer } from "./DeleteServer";
+
+const chance = new Chance();
+
+describe("DeleteServer", () => {
+    const mockServerRepository = mock<ServerRepository>();
+    const mockServerActivityRepository = mock<ServerActivityRepository>();
+    const mockServerManager = mock<ServerManager>();
+    const mockServerManagerFactory = mock<ServerManagerFactory>();
+    const mockEventLogger = mock<EventLogger>();
+    const mockAbortManager = mock<ServerAbortManager>();
+
+    const mockTransaction = mock<Knex.Transaction>();
+
+    const deleteServer = new DeleteServer({
+        serverRepository: mockServerRepository,
+        serverActivityRepository: mockServerActivityRepository,
+        serverManagerFactory: mockServerManagerFactory,
+        eventLogger: mockEventLogger,
+        serverAbortManager: mockAbortManager,
+    });
+
+    const serverId = chance.guid();
+
+    beforeEach(() => {
+        vi.resetAllMocks();
+        mockServerManagerFactory.createServerManager.mockReturnValue(mockServerManager);
+        mockServerRepository.runInTransaction.mockImplementation(async (callback) => {
+            return await callback(mockTransaction);
+        });
+    });
+
+    it("should throw an error if the server does not exist", async () => {
+        mockServerRepository.findById.mockResolvedValue(null);
+
+        await expect(deleteServer.execute({ serverId })).rejects.toThrow("Server not found.");
+
+        expect(mockServerRepository.findById).toHaveBeenCalledWith(serverId, mockTransaction);
+        expect(mockServerManager.deleteServer).not.toHaveBeenCalled();
+    });
+
+    it("should delete a server successfully", async () => {
+        const server: Server = {
+            serverId,
+            region: Region.US_CHICAGO_1,
+            variant: "pugs" as any,
+            hostIp: "1.1.1.1",
+            hostPort: 27015,
+            tvIp: "1.1.1.1",
+            tvPort: 27020,
+            rconPassword: "test",
+            rconAddress: "1.1.1.1:27015",
+            status: "ready" as any,
+            createdBy: chance.guid(),
+        };
+
+        const terminatingServer = { ...server, status: "terminating" as any };
+
+        mockServerRepository.findById
+            .mockResolvedValueOnce(server)
+            .mockResolvedValueOnce(terminatingServer)
+            .mockResolvedValueOnce(terminatingServer);
+
+        mockServerManager.deleteServer.mockResolvedValue();
+        mockServerRepository.deleteServer.mockResolvedValue();
+        mockServerRepository.upsertServer.mockResolvedValue();
+        mockServerActivityRepository.deleteById.mockResolvedValue();
+        mockEventLogger.log.mockResolvedValue();
+        mockAbortManager.getOrCreate.mockReturnValue({ abort: vi.fn(), signal: {} } as any);
+
+        await deleteServer.execute({ serverId });
+
+        expect(mockServerManager.deleteServer).toHaveBeenCalledWith({
+            serverId,
+            region: server.region,
+        });
+        expect(mockServerRepository.deleteServer).toHaveBeenCalledWith(serverId, mockTransaction);
+        expect(mockServerActivityRepository.deleteById).toHaveBeenCalledWith(serverId, mockTransaction);
+        expect(mockEventLogger.log).toHaveBeenCalledWith({
+            eventMessage: expect.stringContaining(serverId),
+            actorId: server.createdBy,
+        });
+    });
+
+    it("should handle the case when server is deleted during transaction", async () => {
+        const server: Server = {
+            serverId,
+            region: Region.US_CHICAGO_1,
+            variant: "pugs" as any,
+            hostIp: "1.1.1.1",
+            hostPort: 27015,
+            tvIp: "1.1.1.1",
+            tvPort: 27020,
+            rconPassword: "test",
+            rconAddress: "1.1.1.1:27015",
+            status: "ready" as any,
+            createdBy: chance.guid(),
+        };
+
+        mockServerRepository.findById
+            .mockResolvedValueOnce(server)
+            .mockResolvedValueOnce(null);
+
+        mockServerManager.deleteServer.mockResolvedValue();
+
+        await deleteServer.execute({ serverId });
+
+        expect(mockServerRepository.deleteServer).not.toHaveBeenCalled();
+        expect(mockServerActivityRepository.deleteById).not.toHaveBeenCalled();
+    });
+
+    it("should abort ongoing signals before deleting", async () => {
+        const server: Server = {
+            serverId,
+            region: Region.US_CHICAGO_1,
+            variant: "pugs" as any,
+            hostIp: "1.1.1.1",
+            hostPort: 27015,
+            tvIp: "1.1.1.1",
+            tvPort: 27020,
+            rconPassword: "test",
+            rconAddress: "1.1.1.1:27015",
+            status: "ready" as any,
+            createdBy: chance.guid(),
+        };
+
+        const terminatingServer = { ...server, status: "terminating" as any };
+        const abortController = { abort: vi.fn(), signal: {} };
+
+        mockServerRepository.findById
+            .mockResolvedValueOnce(server)
+            .mockResolvedValueOnce(terminatingServer)
+            .mockResolvedValueOnce(terminatingServer);
+
+        mockServerManager.deleteServer.mockResolvedValue();
+        mockServerRepository.deleteServer.mockResolvedValue();
+        mockServerRepository.upsertServer.mockResolvedValue();
+        mockServerActivityRepository.deleteById.mockResolvedValue();
+        mockEventLogger.log.mockResolvedValue();
+        mockAbortManager.getOrCreate.mockReturnValue(abortController as any);
+
+        await deleteServer.execute({ serverId });
+
+        expect(abortController.abort).toHaveBeenCalled();
+        expect(mockAbortManager.delete).toHaveBeenCalledWith(serverId);
+    });
+
+    it("should throw an error if server deletion fails", async () => {
+        const server: Server = {
+            serverId,
+            region: Region.US_CHICAGO_1,
+            variant: "pugs" as any,
+            hostIp: "1.1.1.1",
+            hostPort: 27015,
+            tvIp: "1.1.1.1",
+            tvPort: 27020,
+            rconPassword: "test",
+            rconAddress: "1.1.1.1:27015",
+            status: "ready" as any,
+            createdBy: chance.guid(),
+        };
+
+        const terminatingServer = { ...server, status: "terminating" as any };
+        const error = new Error("Failed to delete from provider");
+
+        mockServerRepository.findById
+            .mockResolvedValueOnce(server)
+            .mockResolvedValueOnce(terminatingServer);
+
+        mockServerManager.deleteServer.mockRejectedValue(error);
+
+        await expect(deleteServer.execute({ serverId })).rejects.toThrow("Failed to delete from provider");
+
+        expect(mockServerRepository.deleteServer).not.toHaveBeenCalled();
+    });
+});

--- a/src/core/usecase/DeleteServer.ts
+++ b/src/core/usecase/DeleteServer.ts
@@ -1,0 +1,98 @@
+import { UserError } from "../errors/UserError";
+import { logger } from "../../telemetry/otel";
+import { ServerActivityRepository } from "../repository/ServerActivityRepository";
+import { ServerRepository } from "../repository/ServerRepository";
+import { EventLogger } from "../services/EventLogger";
+import { ServerAbortManager } from "../services/ServerAbortManager";
+import { ServerManagerFactory } from "../../providers/services/ServerManagerFactory";
+
+export class DeleteServer {
+    constructor(
+        private readonly dependencies: {
+            serverRepository: ServerRepository;
+            serverActivityRepository: ServerActivityRepository;
+            serverManagerFactory: ServerManagerFactory;
+            eventLogger: EventLogger;
+            serverAbortManager: ServerAbortManager;
+        }
+    ) {}
+
+    async execute(args: {
+        serverId: string;
+    }): Promise<void> {
+        const { serverRepository, serverActivityRepository, serverManagerFactory, eventLogger, serverAbortManager } = this.dependencies;
+        const { serverId } = args;
+
+        await serverRepository.runInTransaction(async (trx) => {
+            const server = await serverRepository.findById(serverId, trx);
+
+            if (!server) {
+                throw new UserError("Server not found.");
+            }
+
+            await serverRepository.upsertServer({
+                ...server,
+                status: "terminating"
+            }, trx);
+        });
+
+        const server = await serverRepository.findById(serverId);
+
+        if (!server) {
+            logger.emit({
+                severityText: "INFO",
+                body: `Server ${serverId} was already deleted, skipping.`,
+                attributes: { serverId }
+            });
+            return;
+        }
+
+        try {
+            const serverManager = serverManagerFactory.createServerManager(server.region);
+            await serverManager.deleteServer({
+                region: server.region,
+                serverId
+            });
+
+            await serverRepository.runInTransaction(async (trx) => {
+                const existingServer = await serverRepository.findById(serverId, trx);
+                if (!existingServer) {
+                    logger.emit({
+                        severityText: "INFO",
+                        body: `Server ${serverId} no longer exists, skipping cleanup.`,
+                        attributes: { serverId }
+                    });
+                    return;
+                }
+
+                await serverRepository.deleteServer(serverId, trx);
+                await serverActivityRepository.deleteById(serverId, trx);
+
+                const abortController = serverAbortManager.getOrCreate(serverId);
+                abortController.abort();
+                serverAbortManager.delete(serverId);
+
+                await eventLogger.log({
+                    eventMessage: `Server ${serverId} deleted in region ${server.region}.`,
+                    actorId: server.createdBy!,
+                });
+            });
+
+            logger.emit({
+                severityText: "INFO",
+                body: `Server ${serverId} deleted successfully.`,
+                attributes: { serverId }
+            });
+        } catch (error) {
+            logger.emit({
+                severityText: "ERROR",
+                body: `Failed to delete server ${serverId}:`,
+                attributes: {
+                    serverId,
+                    error: JSON.stringify(error, Object.getOwnPropertyNames(error))
+                }
+            });
+            throw error;
+        }
+    }
+}

--- a/src/entrypoints/commands/CreateServer/handler.test.ts
+++ b/src/entrypoints/commands/CreateServer/handler.test.ts
@@ -248,7 +248,7 @@ describe("createServerCommandHandler", () => {
         }).thenReject(new Error("Server creation failed"));
 
         when(backgroundTaskQueue.enqueue).calledWith(
-            "delete-server",
+            "delete-server-for-user",
             { userId: interaction.user.id },
             expect.any(Object)
         ).thenResolve("cleanup-task-id");
@@ -266,7 +266,7 @@ describe("createServerCommandHandler", () => {
 
         // Verify that the cleanup task was enqueued
         expect(backgroundTaskQueue.enqueue).toHaveBeenCalledWith(
-            "delete-server",
+            "delete-server-for-user",
             { userId: interaction.user.id },
             expect.objectContaining({
                 onSuccess: expect.any(Function),

--- a/src/entrypoints/commands/CreateServer/handler.ts
+++ b/src/entrypoints/commands/CreateServer/handler.ts
@@ -16,7 +16,7 @@ import { createInteractionStatusUpdater } from "../../../providers/services/Disc
 import { commandErrorHandler } from "../commandErrorHandler";
 import { defaultGracefulShutdownManager } from "../../../providers/services/DefaultGracefulShutdownManager";
 import { BackgroundTaskQueue } from "../../../core/services/BackgroundTaskQueue";
-import { DeleteServerTaskData } from "../../../providers/queue/DeleteServerTaskProcessor";
+import { DeleteServerForUserTaskData } from "../../../providers/queue/DeleteServerForUserTaskProcessor";
 
 export function createServerCommandHandlerFactory(dependencies: {
     createServerForUser: CreateServerForUser,
@@ -145,8 +145,8 @@ export function createServerCommandHandlerFactory(dependencies: {
 
                         // Trigger cleanup task to delete all user servers (including the failed one)
                         try {
-                            const taskData: DeleteServerTaskData = { userId: buttonInteraction.user.id };
-                            await backgroundTaskQueue.enqueue('delete-server', taskData, {
+                            const taskData: DeleteServerForUserTaskData = { userId: buttonInteraction.user.id };
+                            await backgroundTaskQueue.enqueue('delete-server-for-user', taskData, {
                                 onSuccess: async () => {
                                     logger.emit({
                                         severityText: 'INFO',

--- a/src/entrypoints/commands/TerminateServer/handler.test.ts
+++ b/src/entrypoints/commands/TerminateServer/handler.test.ts
@@ -40,7 +40,7 @@ describe("terminateServerCommandHandler", () => {
         // Then
         expect(interaction.deferReply).toHaveBeenCalled();
         expect(backgroundTaskQueue.enqueue).toHaveBeenCalledWith(
-            "delete-server",
+            "delete-server-for-user",
             { userId },
             expect.objectContaining({
                 onSuccess: expect.any(Function),

--- a/src/entrypoints/commands/TerminateServer/handler.ts
+++ b/src/entrypoints/commands/TerminateServer/handler.ts
@@ -1,6 +1,6 @@
 import { ChatInputCommandInteraction, MessageFlags } from "discord.js";
 import { BackgroundTaskQueue } from "../../../core/services/BackgroundTaskQueue";
-import { DeleteServerTaskData } from "../../../providers/queue/DeleteServerTaskProcessor";
+import { DeleteServerForUserTaskData } from "../../../providers/queue/DeleteServerForUserTaskProcessor";
 import { commandErrorHandler } from "../commandErrorHandler";
 
 export function terminateServerHandlerFactory(dependencies: {
@@ -15,8 +15,8 @@ export function terminateServerHandlerFactory(dependencies: {
         })
 
         try {
-            const taskData: DeleteServerTaskData = { userId };
-            await backgroundTaskQueue.enqueue('delete-server', taskData, {
+            const taskData: DeleteServerForUserTaskData = { userId };
+            await backgroundTaskQueue.enqueue('delete-server-for-user', taskData, {
                 onSuccess: async () => {
                     await interaction.followUp({
                         content: `Server terminated successfully.`,

--- a/src/entrypoints/udp/srcdsCommands/Say.test.ts
+++ b/src/entrypoints/udp/srcdsCommands/Say.test.ts
@@ -68,7 +68,7 @@ describe("say command parser", () => {
                 command: expect.stringContaining("Server is being terminated"),
                 timeout: 5000
             }));
-            expect(services.backgroundTaskQueue.enqueue).toHaveBeenCalledWith('delete-server', { userId: fakeUser.id });
+            expect(services.backgroundTaskQueue.enqueue).toHaveBeenCalledWith('delete-server-for-user', { userId: fakeUser.id });
         });
 
         it("should not terminate if user is not creator", async () => {

--- a/src/entrypoints/udp/srcdsCommands/Say.ts
+++ b/src/entrypoints/udp/srcdsCommands/Say.ts
@@ -35,7 +35,7 @@ export const say: SRCDSCommandParser<{ userId: number, steamId3: string, message
                                 timeout: 5000
                             })
 
-                            await services.backgroundTaskQueue.enqueue('delete-server', { userId: user.id });
+                            await services.backgroundTaskQueue.enqueue('delete-server-for-user', { userId: user.id });
 
                             await eventLogger.log({
                                 eventMessage: `User <@${userId}> initiated server ${server.serverId} termination from inside the game.`,

--- a/src/providers/queue/DeleteServerForUserTaskProcessor.test.ts
+++ b/src/providers/queue/DeleteServerForUserTaskProcessor.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest';
+import { mock } from 'vitest-mock-extended';
+import { when } from 'vitest-when';
+import { DeleteServerForUser } from '../../core/usecase/DeleteServerForUser';
+import { createDeleteServerForUserTaskProcessor } from './DeleteServerForUserTaskProcessor';
+import { GenericTaskProcessor } from './GenericTaskProcessor';
+
+describe('createDeleteServerForUserTaskProcessor', () => {
+  const makeSut = () => {
+    const deleteServerForUser = mock<DeleteServerForUser>();
+    const sut = createDeleteServerForUserTaskProcessor(deleteServerForUser);
+    return { deleteServerForUser, sut };
+  };
+
+  it('should create a GenericTaskProcessor with correct dependencies', () => {
+    const { sut } = makeSut();
+
+    expect(sut).toBeInstanceOf(GenericTaskProcessor);
+  });
+
+  it('should process a delete server for user task successfully', async () => {
+    const { deleteServerForUser, sut } = makeSut();
+    const userId = 'test-user-id';
+
+    when(deleteServerForUser.execute).calledWith({ userId }).thenResolve(undefined);
+
+    await sut.process({ userId });
+
+    expect(deleteServerForUser.execute).toHaveBeenCalledWith({ userId });
+  });
+
+  it('should throw when delete server for user use case fails', async () => {
+    const { deleteServerForUser, sut } = makeSut();
+    const userId = 'test-user-id';
+    const error = new Error('Deletion failed');
+
+    when(deleteServerForUser.execute).calledWith({ userId }).thenReject(error);
+
+    await expect(sut.process({ userId })).rejects.toThrow('Deletion failed');
+  });
+});

--- a/src/providers/queue/DeleteServerForUserTaskProcessor.ts
+++ b/src/providers/queue/DeleteServerForUserTaskProcessor.ts
@@ -1,0 +1,15 @@
+import { GenericTaskProcessor } from './GenericTaskProcessor';
+import { DeleteServerForUser } from '../../core/usecase/DeleteServerForUser';
+
+export type DeleteServerForUserTaskData = {
+  userId: string;
+};
+
+export function createDeleteServerForUserTaskProcessor(
+  deleteServerForUser: DeleteServerForUser
+): GenericTaskProcessor<DeleteServerForUserTaskData> {
+  return new GenericTaskProcessor({
+    useCase: deleteServerForUser,
+    taskName: 'delete-server-for-user',
+  });
+}

--- a/src/providers/queue/DeleteServerTaskProcessor.test.ts
+++ b/src/providers/queue/DeleteServerTaskProcessor.test.ts
@@ -1,15 +1,15 @@
 import { describe, expect, it } from 'vitest';
 import { mock } from 'vitest-mock-extended';
 import { when } from 'vitest-when';
-import { DeleteServerForUser } from '../../core/usecase/DeleteServerForUser';
+import { DeleteServer } from '../../core/usecase/DeleteServer';
 import { createDeleteServerTaskProcessor } from './DeleteServerTaskProcessor';
 import { GenericTaskProcessor } from './GenericTaskProcessor';
 
 describe('createDeleteServerTaskProcessor', () => {
   const makeSut = () => {
-    const deleteServerForUser = mock<DeleteServerForUser>();
-    const sut = createDeleteServerTaskProcessor(deleteServerForUser);
-    return { deleteServerForUser, sut };
+    const deleteServer = mock<DeleteServer>();
+    const sut = createDeleteServerTaskProcessor(deleteServer);
+    return { deleteServer, sut };
   };
 
   it('should create a GenericTaskProcessor with correct dependencies', () => {
@@ -19,24 +19,24 @@ describe('createDeleteServerTaskProcessor', () => {
   });
 
   it('should process a delete server task successfully', async () => {
-    const { deleteServerForUser, sut } = makeSut();
-    const userId = 'test-user-id';
+    const { deleteServer, sut } = makeSut();
+    const serverId = 'test-server-id';
 
-    when(deleteServerForUser.execute).calledWith({ userId }).thenResolve(undefined);
+    when(deleteServer.execute).calledWith({ serverId }).thenResolve(undefined);
 
-    await sut.process({ userId });
+    await sut.process({ serverId });
 
-    expect(deleteServerForUser.execute).toHaveBeenCalledWith({ userId });
+    expect(deleteServer.execute).toHaveBeenCalledWith({ serverId });
   });
 
   it('should throw when delete server use case fails', async () => {
-    const { deleteServerForUser, sut } = makeSut();
-    const userId = 'test-user-id';
+    const { deleteServer, sut } = makeSut();
+    const serverId = 'test-server-id';
     const error = new Error('Deletion failed');
 
-    when(deleteServerForUser.execute).calledWith({ userId }).thenReject(error);
+    when(deleteServer.execute).calledWith({ serverId }).thenReject(error);
 
-    await expect(sut.process({ userId })).rejects.toThrow('Deletion failed');
+    await expect(sut.process({ serverId })).rejects.toThrow('Deletion failed');
   });
 });
 

--- a/src/providers/queue/DeleteServerTaskProcessor.ts
+++ b/src/providers/queue/DeleteServerTaskProcessor.ts
@@ -1,15 +1,15 @@
 import { GenericTaskProcessor } from './GenericTaskProcessor';
-import { DeleteServerForUser } from '../../core/usecase/DeleteServerForUser';
+import { DeleteServer } from '../../core/usecase/DeleteServer';
 
 export type DeleteServerTaskData = {
-  userId: string;
+  serverId: string;
 };
 
 export function createDeleteServerTaskProcessor(
-  deleteServerForUser: DeleteServerForUser
+  deleteServer: DeleteServer
 ): GenericTaskProcessor<DeleteServerTaskData> {
   return new GenericTaskProcessor({
-    useCase: deleteServerForUser,
+    useCase: deleteServer,
     taskName: 'delete-server',
   });
 }


### PR DESCRIPTION
- Creates a new Background Task for deleting Servers by ID (instead of using the User ID)
- Updated the Terminate Empty Servers routine to use this new task
