### PR TITLE
feat(queue): implement retry mechanism for background tasks with configurable backoff

### DIFF
--- a/src/core/services/BackgroundTaskQueue.ts
+++ b/src/core/services/BackgroundTaskQueue.ts
@@ -1,9 +1,19 @@
+export type BackgroundTaskRetryConfig = {
+  maxRetries: number;
+  initialDelayMs?: number;
+  maxDelayMs?: number;
+  backoffMultiplier?: number;
+};
+
 export interface BackgroundTask {
   id: string;
   type: string;
   data: Record<string, unknown>;
   createdAt: Date;
   callbacks?: BackgroundTaskCallbacks;
+  retryConfig?: BackgroundTaskRetryConfig;
+  currentRetryAttempt?: number;
+  scheduledAt?: Date;
 }
 
 export interface BackgroundTaskProcessor<T = Record<string, unknown>> {
@@ -19,7 +29,8 @@ export interface BackgroundTaskQueue {
   enqueue<T extends Record<string, unknown>>(
     type: string,
     data: T,
-    callbacks?: BackgroundTaskCallbacks
+    callbacks?: BackgroundTaskCallbacks,
+    retryConfig?: BackgroundTaskRetryConfig
   ): Promise<string>;
   registerProcessor<T extends Record<string, unknown>>(
     type: string,

--- a/src/core/usecase/DeleteServerForUser.test.ts
+++ b/src/core/usecase/DeleteServerForUser.test.ts
@@ -45,12 +45,10 @@ describe("DeleteServerForUser", () => {
         });
     });
 
-    it("should throw an error if the user has no servers", async () => {
+    it("should return without doing anything if the user has no servers", async () => {
         mockServerRepository.getAllServersByUserId.mockResolvedValue([]);
 
-        await expect(deleteServerForUser.execute({ userId })).rejects.toThrow(
-            "You don't have any servers to terminate."
-        );
+        await deleteServerForUser.execute({ userId });
 
         expect(mockServerRepository.getAllServersByUserId).toHaveBeenCalledWith(userId, mockTransaction);
         expect(mockServerManager.deleteServer).not.toHaveBeenCalled();

--- a/src/core/usecase/DeleteServerForUser.ts
+++ b/src/core/usecase/DeleteServerForUser.ts
@@ -27,7 +27,7 @@ export class DeleteServerForUser {
             const server = await serverRepository.getAllServersByUserId(userId, trx);
 
             if (!server || server.length === 0) {
-                throw new UserError("You don't have any servers to terminate.");
+                return;
             }
 
             // Mark all servers as terminating

--- a/src/core/usecase/TerminateEmptyServers.test.ts
+++ b/src/core/usecase/TerminateEmptyServers.test.ts
@@ -160,7 +160,13 @@ describe("TerminateEmptyServers", () => {
             expect(mocks.backgroundTaskQueue.enqueue).toHaveBeenCalledWith(
                 'delete-server',
                 { serverId: emptyServerToBeTerminated.serverId },
-                expect.any(Object)
+                expect.any(Object),
+                {
+                    maxRetries: 3,
+                    initialDelayMs: 5000,
+                    maxDelayMs: 60000,
+                    backoffMultiplier: 2,
+                }
             );
         });
 
@@ -175,7 +181,13 @@ describe("TerminateEmptyServers", () => {
                 expect(mocks.backgroundTaskQueue.enqueue).not.toHaveBeenCalledWith(
                     'delete-server',
                     { serverId: server.serverId },
-                    expect.any(Object)
+                    expect.any(Object),
+                    {
+                        maxRetries: 3,
+                        initialDelayMs: 5000,
+                        maxDelayMs: 60000,
+                        backoffMultiplier: 2,
+                    }
                 );
             }
         });
@@ -184,7 +196,13 @@ describe("TerminateEmptyServers", () => {
             expect(mocks.backgroundTaskQueue.enqueue).toHaveBeenCalledWith(
                 'delete-server',
                 { serverId: emptyServerToBeTerminated.serverId },
-                expect.any(Object)
+                expect.any(Object),
+                {
+                    maxRetries: 3,
+                    initialDelayMs: 5000,
+                    maxDelayMs: 60000,
+                    backoffMultiplier: 2,
+                }
             );
         });
 

--- a/src/core/usecase/TerminateEmptyServers.ts
+++ b/src/core/usecase/TerminateEmptyServers.ts
@@ -68,6 +68,11 @@ export class TerminateEmptyServers {
                         attributes: { serverId: server.serverId, error: error.message }
                     });
                 }
+            }, {
+                maxRetries: 3,
+                initialDelayMs: 5000,
+                maxDelayMs: 60000,
+                backoffMultiplier: 2,
             });
 
             const index = mergedServers.findIndex((s) => s.serverId === server.serverId);

--- a/src/entrypoints/commands/CreateServer/handler.test.ts
+++ b/src/entrypoints/commands/CreateServer/handler.test.ts
@@ -271,7 +271,13 @@ describe("createServerCommandHandler", () => {
             expect.objectContaining({
                 onSuccess: expect.any(Function),
                 onError: expect.any(Function)
-            })
+            }),
+            {
+                maxRetries: 3,
+                initialDelayMs: 5000,
+                maxDelayMs: 60000,
+                backoffMultiplier: 2,
+            }
         );
     });
 

--- a/src/entrypoints/commands/CreateServer/handler.ts
+++ b/src/entrypoints/commands/CreateServer/handler.ts
@@ -166,6 +166,11 @@ export function createServerCommandHandlerFactory(dependencies: {
                                         }
                                     });
                                 }
+                            }, {
+                                maxRetries: 3,
+                                initialDelayMs: 5000,
+                                maxDelayMs: 60000,
+                                backoffMultiplier: 2,
                             });
                         } catch (queueError) {
                             logger.emit({

--- a/src/entrypoints/commands/TerminateServer/handler.test.ts
+++ b/src/entrypoints/commands/TerminateServer/handler.test.ts
@@ -45,7 +45,13 @@ describe("terminateServerCommandHandler", () => {
             expect.objectContaining({
                 onSuccess: expect.any(Function),
                 onError: expect.any(Function),
-            })
+            }),
+            {
+                maxRetries: 3,
+                initialDelayMs: 5000,
+                maxDelayMs: 60000,
+                backoffMultiplier: 2,
+            }
         );
         expect(interaction.followUp).toHaveBeenCalledWith({
             content: `Server termination has been initiated.`,

--- a/src/entrypoints/commands/TerminateServer/handler.ts
+++ b/src/entrypoints/commands/TerminateServer/handler.ts
@@ -29,6 +29,11 @@ export function terminateServerHandlerFactory(dependencies: {
                         flags: MessageFlags.Ephemeral
                     });
                 }
+            }, {
+                maxRetries: 3,
+                initialDelayMs: 5000,
+                maxDelayMs: 60000,
+                backoffMultiplier: 2,
             });
 
             await interaction.followUp({

--- a/src/entrypoints/udp/srcdsCommands/Say.test.ts
+++ b/src/entrypoints/udp/srcdsCommands/Say.test.ts
@@ -68,7 +68,12 @@ describe("say command parser", () => {
                 command: expect.stringContaining("Server is being terminated"),
                 timeout: 5000
             }));
-            expect(services.backgroundTaskQueue.enqueue).toHaveBeenCalledWith('delete-server-for-user', { userId: fakeUser.id });
+            expect(services.backgroundTaskQueue.enqueue).toHaveBeenCalledWith('delete-server-for-user', { userId: fakeUser.id }, undefined, {
+                maxRetries: 3,
+                initialDelayMs: 5000,
+                maxDelayMs: 60000,
+                backoffMultiplier: 2,
+            });
         });
 
         it("should not terminate if user is not creator", async () => {

--- a/src/entrypoints/udp/srcdsCommands/Say.ts
+++ b/src/entrypoints/udp/srcdsCommands/Say.ts
@@ -35,7 +35,12 @@ export const say: SRCDSCommandParser<{ userId: number, steamId3: string, message
                                 timeout: 5000
                             })
 
-                            await services.backgroundTaskQueue.enqueue('delete-server-for-user', { userId: user.id });
+                            await services.backgroundTaskQueue.enqueue('delete-server-for-user', { userId: user.id }, undefined, {
+                                maxRetries: 3,
+                                initialDelayMs: 5000,
+                                maxDelayMs: 60000,
+                                backoffMultiplier: 2,
+                            });
 
                             await eventLogger.log({
                                 eventMessage: `User <@${userId}> initiated server ${server.serverId} termination from inside the game.`,

--- a/src/providers/queue/InMemoryBackgroundTaskQueue.test.ts
+++ b/src/providers/queue/InMemoryBackgroundTaskQueue.test.ts
@@ -181,4 +181,200 @@ describe('InMemoryBackgroundTaskQueue', () => {
       expect(vi.mocked(shutdownManager.run)).toHaveBeenCalledTimes(3);
     });
   });
+
+  describe('retry mechanism', () => {
+    it('should retry a failing task up to maxRetries times', async () => {
+      const processor = mock<BackgroundTaskProcessor>();
+      processor.process.mockRejectedValueOnce(new Error('First attempt failed'));
+      processor.process.mockRejectedValueOnce(new Error('Second attempt failed'));
+      processor.process.mockResolvedValueOnce(undefined);
+
+      sut.registerProcessor('test-task', processor);
+      await sut.enqueue('test-task', { data: 'test' }, undefined, { maxRetries: 2 });
+      await sut.start();
+
+      await vi.advanceTimersByTimeAsync(2000);
+      await vi.advanceTimersByTimeAsync(2000);
+      await vi.advanceTimersByTimeAsync(2000);
+
+      await sut.stop();
+
+      expect(processor.process).toHaveBeenCalledTimes(3);
+    });
+
+    it('should not retry if maxRetries is 0', async () => {
+      const processor = mock<BackgroundTaskProcessor>();
+      processor.process.mockRejectedValue(new Error('Task failed'));
+      const onError = vi.fn();
+
+      sut.registerProcessor('test-task', processor);
+      await sut.enqueue('test-task', { data: 'test' }, { onError }, { maxRetries: 0 });
+      await sut.start();
+
+      await vi.advanceTimersByTimeAsync(2000);
+
+      await sut.stop();
+
+      expect(processor.process).toHaveBeenCalledTimes(1);
+      expect(onError).toHaveBeenCalledOnce();
+    });
+
+    it('should call onError after exhausting retries', async () => {
+      const processor = mock<BackgroundTaskProcessor>();
+      processor.process.mockRejectedValue(new Error('Always fails'));
+      const onError = vi.fn();
+
+      sut.registerProcessor('test-task', processor);
+      await sut.enqueue('test-task', { data: 'test' }, { onError }, { maxRetries: 2 });
+      await sut.start();
+
+      await vi.advanceTimersByTimeAsync(2000);
+      await vi.advanceTimersByTimeAsync(2000);
+      await vi.advanceTimersByTimeAsync(2000);
+
+      await sut.stop();
+
+      expect(processor.process).toHaveBeenCalledTimes(3);
+      expect(onError).toHaveBeenCalledOnce();
+    });
+
+    it('should use exponential backoff with default configuration', async () => {
+      const processor = mock<BackgroundTaskProcessor>();
+      processor.process.mockRejectedValue(new Error('Task failed'));
+
+      sut.registerProcessor('test-task', processor);
+      await sut.enqueue('test-task', { data: 'test' }, undefined, { maxRetries: 3 });
+      await sut.start();
+
+      await vi.advanceTimersByTimeAsync(1100);
+      expect(processor.process).toHaveBeenCalledTimes(1);
+
+      await vi.advanceTimersByTimeAsync(1500);
+      expect(processor.process).toHaveBeenCalledTimes(2);
+
+      await vi.advanceTimersByTimeAsync(3000);
+      expect(processor.process).toHaveBeenCalledTimes(3);
+
+      await vi.advanceTimersByTimeAsync(7000);
+      expect(processor.process).toHaveBeenCalledTimes(4);
+
+      await sut.stop();
+    });
+
+    it('should use custom backoff configuration', async () => {
+      const processor = mock<BackgroundTaskProcessor>();
+      processor.process.mockRejectedValue(new Error('Task failed'));
+
+      sut.registerProcessor('test-task', processor);
+      await sut.enqueue('test-task', { data: 'test' }, undefined, {
+        maxRetries: 2,
+        initialDelayMs: 500,
+        maxDelayMs: 10000,
+        backoffMultiplier: 3,
+      });
+      await sut.start();
+
+      await vi.advanceTimersByTimeAsync(1100);
+      expect(processor.process).toHaveBeenCalledTimes(1);
+
+      await vi.advanceTimersByTimeAsync(1000);
+      expect(processor.process).toHaveBeenCalledTimes(2);
+
+      await vi.advanceTimersByTimeAsync(2000);
+      expect(processor.process).toHaveBeenCalledTimes(3);
+
+      await sut.stop();
+    });
+
+    it('should respect maxDelayMs in backoff calculation', async () => {
+      const processor = mock<BackgroundTaskProcessor>();
+      processor.process.mockRejectedValue(new Error('Task failed'));
+
+      sut.registerProcessor('test-task', processor);
+      await sut.enqueue('test-task', { data: 'test' }, undefined, {
+        maxRetries: 3,
+        initialDelayMs: 10000,
+        maxDelayMs: 5000,
+        backoffMultiplier: 2,
+      });
+      await sut.start();
+
+      await vi.advanceTimersByTimeAsync(2000);
+      expect(processor.process).toHaveBeenCalledTimes(1);
+
+      await vi.advanceTimersByTimeAsync(5100);
+      expect(processor.process).toHaveBeenCalledTimes(2);
+
+      await vi.advanceTimersByTimeAsync(5100);
+      expect(processor.process).toHaveBeenCalledTimes(3);
+
+      await sut.stop();
+    });
+
+    it('should call onSuccess after successful retry', async () => {
+      const processor = mock<BackgroundTaskProcessor>();
+      processor.process.mockRejectedValueOnce(new Error('First attempt failed'));
+      processor.process.mockResolvedValueOnce({ success: true });
+      const onSuccess = vi.fn();
+
+      sut.registerProcessor('test-task', processor);
+      await sut.enqueue('test-task', { data: 'test' }, { onSuccess }, { maxRetries: 1 });
+      await sut.start();
+
+      await vi.advanceTimersByTimeAsync(2000);
+      await vi.advanceTimersByTimeAsync(2000);
+
+      await sut.stop();
+
+      expect(processor.process).toHaveBeenCalledTimes(2);
+      expect(onSuccess).toHaveBeenCalledWith({ success: true });
+    });
+
+    it('should process retried tasks in order with other tasks', async () => {
+      const processor = mock<BackgroundTaskProcessor>();
+      const results: string[] = [];
+
+      let callCount = 0;
+      processor.process.mockImplementation(async (data: Record<string, unknown>) => {
+        callCount++;
+        if (callCount === 1) {
+          throw new Error('Task 1 fails first');
+        }
+        results.push(data.id as string);
+      });
+
+      sut.registerProcessor('test-task', processor);
+
+      await sut.enqueue('test-task', { id: '1' }, undefined, { maxRetries: 1 });
+      await sut.enqueue('test-task', { id: '2' });
+      await sut.enqueue('test-task', { id: '3' });
+
+      await sut.start();
+
+      await vi.advanceTimersByTimeAsync(3500);
+      expect(results).toEqual(['2', '3']);
+
+      await vi.advanceTimersByTimeAsync(1500);
+      expect(results).toEqual(['2', '3', '1']);
+
+      await sut.stop();
+    });
+
+    it('should not retry if no retryConfig is provided', async () => {
+      const processor = mock<BackgroundTaskProcessor>();
+      processor.process.mockRejectedValue(new Error('Task failed'));
+      const onError = vi.fn();
+
+      sut.registerProcessor('test-task', processor);
+      await sut.enqueue('test-task', { data: 'test' }, { onError });
+      await sut.start();
+
+      await vi.advanceTimersByTimeAsync(2000);
+
+      await sut.stop();
+
+      expect(processor.process).toHaveBeenCalledTimes(1);
+      expect(onError).toHaveBeenCalledOnce();
+    });
+  });
 });

--- a/src/providers/queue/InMemoryBackgroundTaskQueue.ts
+++ b/src/providers/queue/InMemoryBackgroundTaskQueue.ts
@@ -1,5 +1,5 @@
 import { logger } from '../../telemetry/otel';
-import { BackgroundTask, BackgroundTaskQueue, BackgroundTaskProcessor, BackgroundTaskCallbacks } from '../../core/services/BackgroundTaskQueue';
+import { BackgroundTask, BackgroundTaskQueue, BackgroundTaskProcessor, BackgroundTaskCallbacks, BackgroundTaskRetryConfig } from '../../core/services/BackgroundTaskQueue';
 import { GracefulShutdownManager } from '../../core/services/GracefulShutdownManager';
 
 export class InMemoryBackgroundTaskQueue implements BackgroundTaskQueue {
@@ -8,6 +8,12 @@ export class InMemoryBackgroundTaskQueue implements BackgroundTaskQueue {
   private running = false;
   private processingInterval: NodeJS.Timeout | null = null;
   private readonly processingDelayMs = 1000;
+  private readonly defaultRetryConfig: Required<BackgroundTaskRetryConfig> = {
+    maxRetries: 0,
+    initialDelayMs: 1000,
+    maxDelayMs: 60000,
+    backoffMultiplier: 2,
+  };
 
   constructor(private readonly shutdownManager: GracefulShutdownManager) {}
 
@@ -21,15 +27,20 @@ export class InMemoryBackgroundTaskQueue implements BackgroundTaskQueue {
   async enqueue<T extends Record<string, unknown>>(
     type: string,
     data: T,
-    callbacks?: BackgroundTaskCallbacks
+    callbacks?: BackgroundTaskCallbacks,
+    retryConfig?: BackgroundTaskRetryConfig
   ): Promise<string> {
     const id = `task-${Date.now()}-${Math.random().toString(36).substr(2, 9)}`;
+    const mergedRetryConfig = retryConfig ? { ...this.defaultRetryConfig, ...retryConfig } : undefined;
     const task: BackgroundTask = {
       id,
       type,
       data,
       createdAt: new Date(),
       callbacks,
+      retryConfig: mergedRetryConfig,
+      currentRetryAttempt: 0,
+      scheduledAt: new Date(),
     };
 
     this.tasks.push(task);
@@ -40,6 +51,7 @@ export class InMemoryBackgroundTaskQueue implements BackgroundTaskQueue {
       attributes: {
         taskId: id,
         taskType: type,
+        maxRetries: mergedRetryConfig?.maxRetries ?? 0,
       },
     });
 
@@ -89,7 +101,14 @@ export class InMemoryBackgroundTaskQueue implements BackgroundTaskQueue {
       return;
     }
 
-    const task = this.tasks.shift();
+    const now = new Date();
+    const readyTaskIndex = this.tasks.findIndex((task) => !task.scheduledAt || task.scheduledAt <= now);
+
+    if (readyTaskIndex === -1) {
+      return;
+    }
+
+    const task = this.tasks.splice(readyTaskIndex, 1)[0];
     if (!task) {
       return;
     }
@@ -115,6 +134,8 @@ export class InMemoryBackgroundTaskQueue implements BackgroundTaskQueue {
           attributes: {
             taskId: task.id,
             taskType: task.type,
+            attempt: (task.currentRetryAttempt ?? 0) + 1,
+            maxRetries: task.retryConfig?.maxRetries ?? 0,
           },
         });
 
@@ -126,6 +147,7 @@ export class InMemoryBackgroundTaskQueue implements BackgroundTaskQueue {
           attributes: {
             taskId: task.id,
             taskType: task.type,
+            attempt: (task.currentRetryAttempt ?? 0) + 1,
           },
         });
 
@@ -134,19 +156,71 @@ export class InMemoryBackgroundTaskQueue implements BackgroundTaskQueue {
         }
       });
     } catch (error) {
+      const currentAttempt = task.currentRetryAttempt ?? 0;
+      const maxRetries = task.retryConfig?.maxRetries ?? 0;
+      const shouldRetry = currentAttempt < maxRetries;
+
       logger.emit({
         severityText: 'ERROR',
-        body: 'Background task failed',
+        body: `Background task failed${shouldRetry ? ', will retry' : ''}`,
         attributes: {
           taskId: task.id,
           taskType: task.type,
+          attempt: currentAttempt + 1,
+          maxRetries,
+          shouldRetry,
           error: JSON.stringify(error, Object.getOwnPropertyNames(error)),
         },
       });
 
-      if (task.callbacks?.onError) {
-        await task.callbacks.onError(error instanceof Error ? error : new Error(String(error)));
+      if (shouldRetry) {
+        this.scheduleRetry(task, currentAttempt + 1);
+      } else {
+        if (task.callbacks?.onError) {
+          await task.callbacks.onError(error instanceof Error ? error : new Error(String(error)));
+        }
       }
     }
+  }
+
+  private scheduleRetry(task: BackgroundTask, nextAttempt: number): void {
+    const config = task.retryConfig;
+    if (!config) {
+      return;
+    }
+
+    const mergedConfig: Required<BackgroundTaskRetryConfig> = {
+      maxRetries: config.maxRetries,
+      initialDelayMs: config.initialDelayMs ?? this.defaultRetryConfig.initialDelayMs,
+      maxDelayMs: config.maxDelayMs ?? this.defaultRetryConfig.maxDelayMs,
+      backoffMultiplier: config.backoffMultiplier ?? this.defaultRetryConfig.backoffMultiplier,
+    };
+
+    const delay = this.calculateBackoffDelay(nextAttempt, mergedConfig);
+    const scheduledAt = new Date(Date.now() + delay);
+
+    task.currentRetryAttempt = nextAttempt;
+    task.scheduledAt = scheduledAt;
+
+    this.tasks.push(task);
+
+    logger.emit({
+      severityText: 'INFO',
+      body: 'Background task scheduled for retry',
+      attributes: {
+        taskId: task.id,
+        taskType: task.type,
+        nextAttempt,
+        delayMs: delay,
+      },
+    });
+  }
+
+  private calculateBackoffDelay(
+    attemptNumber: number,
+    config: Required<BackgroundTaskRetryConfig>
+  ): number {
+    const exponentialDelay = config.initialDelayMs * Math.pow(config.backoffMultiplier, attemptNumber - 1);
+    return Math.min(exponentialDelay, config.maxDelayMs);
   }
 }


### PR DESCRIPTION
Solves https://github.com/sonikro/TF2-QuickServer/issues/196 by implementing an auto-retry mechanism for BackgroundTasks and making the delete-server task a retryable task