### PR TITLE
fix: replace direct uuid import with IdGenerator in CreateServerForUser

### DIFF
--- a/packages/core/src/usecase/CreateServerForUser.test.ts
+++ b/packages/core/src/usecase/CreateServerForUser.test.ts
@@ -9,17 +9,12 @@ import { ServerRepository } from '../repository/ServerRepository';
 import { UserCreditsRepository } from '../repository/UserCreditsRepository';
 import { UserRepository } from '../repository/UserRepository';
 import { EventLogger } from '../services/EventLogger';
+import { IdGenerator } from '../services/IdGenerator';
 import { ServerManager } from '../services/ServerManager';
 import { ServerManagerFactory } from '@tf2qs/providers';
 import { ConfigManager } from '../utils/ConfigManager';
 import { CreateServerForUser } from './CreateServerForUser';
 import { UserBanRepository } from '../repository/UserBanRepository';
-
-vi.mock("uuid", () => {
-    return {
-        v4: () => "test-uuid"
-    }
-})
 
 const chance = new Chance();
 
@@ -33,12 +28,15 @@ const createTestEnvironment = () => {
     const configManager = mock<ConfigManager>();
     const userRepository = mock<UserRepository>();
     const guildParametersRepository = mock<GuildParametersRepository>();
+    const idGenerator = mock<IdGenerator>();
     const userBanRepository = mock<UserBanRepository>({
         isUserBanned: vi.fn().mockResolvedValue({ isBanned: false, reason: '' })
     });
 
     // Configure the factory to return the mocked server manager for any Region
     serverManagerFactory.createServerManager.mockReturnValue(serverManager);
+
+    when(idGenerator.generate).calledWith().thenReturn("test-uuid");
 
     when(configManager.getCreditsConfig).calledWith().thenReturn({
         enabled: true
@@ -104,6 +102,7 @@ const createTestEnvironment = () => {
             userRepository,
             guildParametersRepository,
             userBanRepository,
+            idGenerator,
         }),
         mocks: {
             serverRepository,
@@ -116,6 +115,7 @@ const createTestEnvironment = () => {
             userRepository,
             guildParametersRepository,
             userBanRepository,
+            idGenerator,
             trx,
             statusUpdater
         },

--- a/packages/core/src/usecase/CreateServerForUser.ts
+++ b/packages/core/src/usecase/CreateServerForUser.ts
@@ -6,10 +6,10 @@ import { UserCreditsRepository } from "../repository/UserCreditsRepository";
 import { UserRepository } from "../repository/UserRepository";
 import { UserBanRepository } from "../repository/UserBanRepository";
 import { EventLogger } from "../services/EventLogger";
+import { IdGenerator } from "../services/IdGenerator";
 import { ServerManagerFactory } from '@tf2qs/providers';
 import { StatusUpdater } from "../services/StatusUpdater";
 import { ConfigManager } from "../utils/ConfigManager";
-import { v4 as uuid } from "uuid";
 import SteamID from "steamid";
 import { logger } from '@tf2qs/telemetry';
 export class CreateServerForUser {
@@ -24,6 +24,7 @@ export class CreateServerForUser {
         configManager: ConfigManager,
         userRepository: UserRepository,
         userBanRepository: UserBanRepository,
+        idGenerator: IdGenerator,
     }) { }
 
     public async execute(args: {
@@ -33,7 +34,7 @@ export class CreateServerForUser {
         guildId: string,
         statusUpdater: StatusUpdater
     }): Promise<Server> {
-        const { serverManagerFactory, serverRepository, userCreditsRepository, eventLogger, sourceTvEventLogger, configManager, userRepository, guildParametersRepository, userBanRepository } = this.dependencies;
+        const { serverManagerFactory, serverRepository, userCreditsRepository, eventLogger, sourceTvEventLogger, configManager, userRepository, guildParametersRepository, userBanRepository, idGenerator } = this.dependencies;
         const statusUpdater = args.statusUpdater;
         
         const serverManager = serverManagerFactory.createServerManager(args.region);
@@ -92,7 +93,7 @@ export class CreateServerForUser {
                 throw new UserError('You do not have enough credits to start a server.')
             }
         }
-        const serverId = uuid();
+        const serverId = idGenerator.generate();
 
         await serverRepository.runInTransaction(async (trx) => {
             const allServers = await serverRepository.getAllServersByUserId(args.creatorId, trx);

--- a/packages/entrypoints/src/discordBot.ts
+++ b/packages/entrypoints/src/discordBot.ts
@@ -190,7 +190,8 @@ export async function startDiscordBot() {
             configManager: defaultConfigManager,
             userRepository,
             guildParametersRepository,
-            userBanRepository
+            userBanRepository,
+            idGenerator: new UuidIdGenerator()
         }),
         createCreditsPurchaseOrder: new CreateCreditsPurchaseOrder({
             creditOrdersRepository,


### PR DESCRIPTION
## Summary

Fixes #265

## Changes

- **`CreateServerForUser.ts`**: Added `idGenerator: IdGenerator` to the dependencies object, replaced `uuid()` call with `idGenerator.generate()`, and removed the direct `uuid` library import
- **`discordBot.ts`**: Pass `idGenerator: new UuidIdGenerator()` when wiring `CreateServerForUser`  
- **`CreateServerForUser.test.ts`**: Removed `vi.mock("uuid")` and replaced with a proper `IdGenerator` mock via `vitest-mock-extended`

## Why

The core layer must not have direct external library dependencies. The `IdGenerator` interface already exists in `packages/core/src/services/IdGenerator.ts` for this purpose, and the sibling use case `CreateServerForClient` already follows this pattern correctly.