### PR TITLE
tech debt #264: fix core -> providers import direction

### DIFF
--- a/packages/core/src/usecase/CreateServerForUser.ts
+++ b/packages/core/src/usecase/CreateServerForUser.ts
@@ -7,7 +7,7 @@ import { UserRepository } from "../repository/UserRepository";
 import { UserBanRepository } from "../repository/UserBanRepository";
 import { EventLogger } from "../services/EventLogger";
 import { IdGenerator } from "../services/IdGenerator";
-import { ServerManagerFactory } from '@tf2qs/providers';
+import { ServerManagerFactory } from '@tf2qs/core';
 import { StatusUpdater } from "../services/StatusUpdater";
 import { ConfigManager } from "../utils/ConfigManager";
 import SteamID from "steamid";

--- a/packages/core/src/usecase/DeleteServer.ts
+++ b/packages/core/src/usecase/DeleteServer.ts
@@ -4,7 +4,7 @@ import { ServerActivityRepository } from "../repository/ServerActivityRepository
 import { ServerRepository } from "../repository/ServerRepository";
 import { EventLogger } from "../services/EventLogger";
 import { ServerAbortManager } from "../services/ServerAbortManager";
-import { ServerManagerFactory } from '@tf2qs/providers';
+import { ServerManagerFactory } from '@tf2qs/core';
 
 export class DeleteServer {
     constructor(

--- a/packages/core/src/usecase/DeleteServerForUser.ts
+++ b/packages/core/src/usecase/DeleteServerForUser.ts
@@ -3,7 +3,7 @@ import { ServerActivityRepository } from "../repository/ServerActivityRepository
 import { ServerRepository } from "../repository/ServerRepository";
 import { EventLogger } from "../services/EventLogger";
 import { ServerAbortManager } from "../services/ServerAbortManager";
-import { ServerManagerFactory } from '@tf2qs/providers';
+import { ServerManagerFactory } from '@tf2qs/core';
 
 export class DeleteServerForUser {
     constructor(

--- a/packages/core/src/usecase/TerminateLongRunningServers.ts
+++ b/packages/core/src/usecase/TerminateLongRunningServers.ts
@@ -1,7 +1,7 @@
 import { ServerRepository } from "../repository/ServerRepository";
 import { EventLogger } from "../services/EventLogger";
 import { ServerCommander } from "../services/ServerCommander";
-import { ServerManagerFactory } from '@tf2qs/providers';
+import { ServerManagerFactory } from '@tf2qs/core';
 
 const MAX_HOURS = 12
 

--- a/packages/core/src/usecase/TerminatePendingServers.ts
+++ b/packages/core/src/usecase/TerminatePendingServers.ts
@@ -1,5 +1,5 @@
 import { ServerRepository } from "../repository/ServerRepository";
-import { ServerManagerFactory } from '@tf2qs/providers';
+import { ServerManagerFactory } from '@tf2qs/core';
 import { EventLogger } from "../services/EventLogger";
 import { Client as DiscordClient } from "discord.js";
 import { ServerStatus } from "../domain/DeployedServer";

--- a/packages/core/src/usecase/TerminateServersWithoutCredit.ts
+++ b/packages/core/src/usecase/TerminateServersWithoutCredit.ts
@@ -2,7 +2,7 @@ import { ServerRepository } from "../repository/ServerRepository";
 import { UserCreditsRepository } from "../repository/UserCreditsRepository";
 import { EventLogger } from "../services/EventLogger";
 import { ServerCommander } from "../services/ServerCommander";
-import { ServerManagerFactory } from '@tf2qs/providers';
+import { ServerManagerFactory } from '@tf2qs/core';
 
 export class TerminateServersWithoutCredit {
 


### PR DESCRIPTION
## Summary
Fixes tech debt issue #264 by correcting dependency direction in core use cases.

### Changes
Updated `ServerManagerFactory` imports in core use cases from `@tf2qs/providers` to `@tf2qs/core`:
- `packages/core/src/usecase/CreateServerForUser.ts`
- `packages/core/src/usecase/DeleteServer.ts`
- `packages/core/src/usecase/DeleteServerForUser.ts`
- `packages/core/src/usecase/TerminateLongRunningServers.ts`
- `packages/core/src/usecase/TerminatePendingServers.ts`
- `packages/core/src/usecase/TerminateServersWithoutCredit.ts`

## Why
Core should not depend on providers in Clean Architecture. This change keeps dependency flow inward and uses the interface re-exported by core.

Closes #264