### PR TITLE
Disable Dodgeball plugins by default

### DIFF
--- a/variants/base/tf/cfg/dodgeball.cfg
+++ b/variants/base/tf/cfg/dodgeball.cfg
@@ -2,3 +2,5 @@
 // The TF2Dodgeball plugin automatically enables on tfdb_* maps
 // Add any game-specific cvars or commands here
 
+sm plugins load dodgeball
+sm plugins load tfdb_pvb

--- a/variants/base/tf/cfg/server.cfg.template
+++ b/variants/base/tf/cfg/server.cfg.template
@@ -27,3 +27,7 @@ recordstv_path "demos"
 
 log on
 sv_logsecret "${SV_LOGSECRET}"
+
+// Keep Dodgeball plugins disabled by default; enabled only by dodgeball.cfg on tfdb maps.
+sm plugins unload dodgeball
+sm plugins unload tfdb_pvb


### PR DESCRIPTION
## Summary
- unload `dodgeball` and `tfdb_pvb` by default in `server.cfg.template`
- load only `dodgeball` in `dodgeball.cfg`

## Why
The Dodgeball package includes PvB defaults that can spawn a bot when the first player joins. This keeps dodgeball opt-in per map config and prevents bot auto-loading by default.
