### PR TITLE
feat(variants): add publicServer option to skip sv_password/tv_password generation

### DIFF
--- a/config/default.json
+++ b/config/default.json
@@ -71,6 +71,7 @@
             "displayName": "PUBSTAR Casual",
             "hostname": "PUBSTAR @ TF2-QuickServer",
             "emptyMinutesTerminate": 60,
+            "publicServer": true,
             "map": "pl_badwater",
             "image": "sonikro/fat-tf2-casual-i386:latest",
             "defaultCfgs": {
@@ -88,6 +89,7 @@
             "displayName": "Frisbeeverse",
             "hostname": "Frisbeeverse @ TF2-QuickServer",
             "emptyMinutesTerminate": 60,
+            "publicServer": true,
             "map": "pl_badwater",
             "image": "sonikro/fat-tf2-casual-i386:latest",
             "defaultCfgs": {

--- a/packages/core/src/domain/Variant.ts
+++ b/packages/core/src/domain/Variant.ts
@@ -44,6 +44,14 @@ export type VariantConfig = {
      * If not set, the default server connection message will be shown.
      */
     customCreationMessage?: string;
+
+    /**
+     * If true, the server is a public server that does not need sv_password or tv_password.
+     * Both will be set to empty strings, making the server publicly joinable without a password.
+     * Useful for casual/public variants where unrestricted access is desired.
+     * The rconPassword and logSecret are still generated for server management purposes.
+     */
+    publicServer?: boolean;
 }
 
 export function getVariantConfig(variant: Variant) {

--- a/packages/core/src/models/ServerCredentials.test.ts
+++ b/packages/core/src/models/ServerCredentials.test.ts
@@ -106,4 +106,66 @@ describe("ServerCredentials", () => {
         });
     });
 
+    describe("generate with publicServer option", () => {
+        it("should set serverPassword and tvPassword to empty strings when publicServer is true", () => {
+            const { mocks } = createTestEnvironment();
+            
+            mocks.passwordGeneratorService.generatePassword.mockReturnValue("rcon-generated");
+            mocks.passwordGeneratorService.generateNumericPassword.mockReturnValue(999999);
+
+            const credentials = ServerCredentials.generate(mocks.passwordGeneratorService, { publicServer: true });
+
+            expect(credentials.serverPassword).toBe("");
+            expect(credentials.tvPassword).toBe("");
+            expect(credentials.rconPassword).toBe("rcon-generated");
+            expect(credentials.logSecret).toBe(999999);
+        });
+
+        it("should only call generatePassword for rconPassword when publicServer is true", () => {
+            const { mocks } = createTestEnvironment();
+            
+            mocks.passwordGeneratorService.generatePassword.mockReturnValue("rcon-generated");
+            mocks.passwordGeneratorService.generateNumericPassword.mockReturnValue(123456);
+
+            ServerCredentials.generate(mocks.passwordGeneratorService, { publicServer: true });
+
+            // generatePassword should only be called once for rconPassword
+            expect(mocks.passwordGeneratorService.generatePassword).toHaveBeenCalledTimes(1);
+            expect(mocks.passwordGeneratorService.generatePassword).toHaveBeenCalledWith({
+                alpha: true,
+                length: 10,
+                numeric: true,
+                symbols: false
+            });
+        });
+
+        it("should still call generateNumericPassword for logSecret when publicServer is true", () => {
+            const { mocks } = createTestEnvironment();
+            
+            mocks.passwordGeneratorService.generatePassword.mockReturnValue("rcon-generated");
+            mocks.passwordGeneratorService.generateNumericPassword.mockReturnValue(123456);
+
+            ServerCredentials.generate(mocks.passwordGeneratorService, { publicServer: true });
+
+            const expectedNumericSettings = { min: 1, max: 999999 };
+
+            expect(mocks.passwordGeneratorService.generateNumericPassword).toHaveBeenCalledTimes(1);
+            expect(mocks.passwordGeneratorService.generateNumericPassword).toHaveBeenCalledWith(expectedNumericSettings);
+        });
+
+        it("should behave the same as default when publicServer is false or undefined", () => {
+            const { mocks } = createTestEnvironment();
+            
+            mocks.passwordGeneratorService.generatePassword.mockReturnValue("server-password");
+            mocks.passwordGeneratorService.generateNumericPassword.mockReturnValue(111111);
+
+            const credentialsDefault = ServerCredentials.generate(mocks.passwordGeneratorService);
+            const credentialsFalse = ServerCredentials.generate(mocks.passwordGeneratorService, { publicServer: false });
+
+            expect(credentialsDefault.serverPassword).toBe("server-password");
+            expect(credentialsDefault.tvPassword).toBe("server-password");
+            expect(credentialsFalse.serverPassword).toBe("server-password");
+            expect(credentialsFalse.tvPassword).toBe("server-password");
+        });
+    });
 });

--- a/packages/core/src/models/ServerCredentials.ts
+++ b/packages/core/src/models/ServerCredentials.ts
@@ -24,13 +24,13 @@ export class ServerCredentials {
     /**
      * Creates ServerCredentials with generated passwords
      */
-    static generate(passwordGeneratorService: PasswordGeneratorService): ServerCredentials {
+    static generate(passwordGeneratorService: PasswordGeneratorService, options?: { publicServer?: boolean }): ServerCredentials {
         const passwordSettings = { alpha: true, length: 10, numeric: true, symbols: false, };
 
         return new ServerCredentials({
-            serverPassword: passwordGeneratorService.generatePassword(passwordSettings),
+            serverPassword: options?.publicServer ? '' : passwordGeneratorService.generatePassword(passwordSettings),
             rconPassword: passwordGeneratorService.generatePassword(passwordSettings),
-            tvPassword: passwordGeneratorService.generatePassword(passwordSettings),
+            tvPassword: options?.publicServer ? '' : passwordGeneratorService.generatePassword(passwordSettings),
             logSecret: passwordGeneratorService.generateNumericPassword({ min: 1, max: 999999 })
         });
     }

--- a/packages/providers/src/cloud-providers/aws/AWSServerManager.test.ts
+++ b/packages/providers/src/cloud-providers/aws/AWSServerManager.test.ts
@@ -243,6 +243,41 @@ describe("AWSServerManager", () => {
             });
         });
 
+        it("should pass empty serverPassword and tvPassword when publicServer is true", async () => {
+            const publicMockVariantConfig = {
+                ...mockVariantConfig,
+                publicServer: true,
+            };
+            vi.mocked(mockConfigManager.getVariantConfig).mockReturnValue(publicMockVariantConfig);
+
+            const serverManager = new AWSServerManager(
+                mockTaskDefinitionService,
+                mockSecurityGroupService,
+                mockEC2InstanceService,
+                mockECSServiceManager,
+                mockNetworkService,
+                mockTF2ServerReadinessService,
+                mockEnvironmentBuilderService,
+                mockPasswordGeneratorService,
+                mockConfigManager
+            );
+
+            await serverManager.deployServer(deployArgs);
+
+            // Verify that credentials passed to environmentBuilder have empty server/tv passwords
+            expect(mockEnvironmentBuilderService.build).toHaveBeenCalledWith(
+                expect.objectContaining({ serverId: "test-server-123" }),
+                expect.objectContaining({
+                    serverPassword: "",
+                    tvPassword: "",
+                    rconPassword: "password123",
+                    logSecret: 12345
+                }),
+                expect.objectContaining({ publicServer: true }),
+                expect.anything()
+            );
+        });
+
         it("handles deployment errors correctly", async () => {
             const error = new Error("Security group creation failed");
             vi.mocked(mockSecurityGroupService.create).mockRejectedValue(error);

--- a/packages/providers/src/cloud-providers/aws/AWSServerManager.ts
+++ b/packages/providers/src/cloud-providers/aws/AWSServerManager.ts
@@ -113,12 +113,12 @@ export class AWSServerManager implements ServerManager {
                 attributes: { serverId: args.serverId, region: args.region, variant: args.variantName }
             });
 
-            // Generate server credentials
-            const credentials = ServerCredentials.generate(this.passwordGeneratorService);
-
             // Get configuration
             const variantConfig = this.configManager.getVariantConfig(args.variantName);
             const regionConfig = this.configManager.getRegionConfig(args.region);
+
+            // Generate server credentials
+            const credentials = ServerCredentials.generate(this.passwordGeneratorService, { publicServer: variantConfig.publicServer });
 
             // Build environment variables
             const environment = this.environmentBuilderService.build(context, credentials, variantConfig, regionConfig);

--- a/packages/providers/src/cloud-providers/oracle/OCIServerManager.test.ts
+++ b/packages/providers/src/cloud-providers/oracle/OCIServerManager.test.ts
@@ -662,6 +662,55 @@ describe("OCIServerManager", () => {
     });
   });
 
+  describe("publicServer variant", () => {
+    it("should set SERVER_PASSWORD and STV_PASSWORD to empty strings when publicServer is true", async () => {
+      const { sut, containerClient, variantConfig } = createTestEnvironment();
+      const statusUpdater = vi.fn();
+      variantConfig.publicServer = true;
+
+      await sut.deployServer({
+        region: testRegion,
+        variantName: testVariant,
+        sourcemodAdminSteamId: "12345678901234567",
+        serverId: "public-server-test",
+        statusUpdater,
+      });
+
+      const containerInstanceRequest = containerClient.createContainerInstance.mock.calls[0][0];
+      const tf2Container = containerInstanceRequest.createContainerInstanceDetails.containers.find(
+        (c: any) => c.displayName === "public-server-test"
+      );
+
+      expect(tf2Container?.environmentVariables?.SERVER_PASSWORD).toBe("");
+      expect(tf2Container?.environmentVariables?.STV_PASSWORD).toBe("");
+      // RCON password should still be generated
+      expect(tf2Container?.environmentVariables?.RCON_PASSWORD).toBe("test-password");
+    });
+
+    it("should generate passwords as normal when publicServer is false or unset", async () => {
+      const { sut, containerClient, variantConfig } = createTestEnvironment();
+      const statusUpdater = vi.fn();
+
+      // Default: publicServer is undefined
+      await sut.deployServer({
+        region: testRegion,
+        variantName: testVariant,
+        sourcemodAdminSteamId: "12345678901234567",
+        serverId: "public-server-false-test",
+        statusUpdater,
+      });
+
+      const containerInstanceRequest = containerClient.createContainerInstance.mock.calls[0][0];
+      const tf2Container = containerInstanceRequest.createContainerInstanceDetails.containers.find(
+        (c: any) => c.displayName === "public-server-false-test"
+      );
+
+      expect(tf2Container?.environmentVariables?.SERVER_PASSWORD).toBe("test-password");
+      expect(tf2Container?.environmentVariables?.STV_PASSWORD).toBe("test-password");
+      expect(tf2Container?.environmentVariables?.RCON_PASSWORD).toBe("test-password");
+    });
+  });
+
   describe("abort server deployment", () => {
     it("should throw an AbortError if the deployment is aborted", async () => {
       const { sut, serverAbortManager, statusUpdater } = createTestEnvironment();

--- a/packages/providers/src/cloud-providers/oracle/OCIServerManager.ts
+++ b/packages/providers/src/cloud-providers/oracle/OCIServerManager.ts
@@ -120,9 +120,9 @@ export class OCIServerManager implements ServerManager {
                 }
 
                 const passwordSettings = { alpha: true, length: 10, numeric: true, symbols: false };
-                const serverPassword = passwordGeneratorService.generatePassword(passwordSettings);
+                const serverPassword = variantConfig.publicServer ? '' : passwordGeneratorService.generatePassword(passwordSettings);
                 const rconPassword = passwordGeneratorService.generatePassword(passwordSettings);
-                const tvPassword = passwordGeneratorService.generatePassword(passwordSettings);
+                const tvPassword = variantConfig.publicServer ? '' : passwordGeneratorService.generatePassword(passwordSettings);
 
                 const containerImage = variantConfig.image;
                 const startupMap = firstMap ?? variantConfig.map;


### PR DESCRIPTION
## Summary

Adds a per-variant `publicServer` boolean configuration option. When `true`, both `sv_password` and `tv_password` are set to empty strings — making the server publicly joinable without a password. `rconPassword` and `logSecret` are still generated since they're needed for server management via the SHIELD sidecar.

This is motivated by casual variants (`pubstar-casual`, `frisbeeverse`) which currently generate passwords unnecessarily — their `casual_base.cfg` already clears `sv_password` via CFG, but the passwords were still generated, stored in the database, and shown to users in the Discord `/create-server` command output.

## Changes

- **`VariantConfig`** (`packages/core/src/domain/Variant.ts`): Added `publicServer?: boolean` property
- **`ServerCredentials.generate()`** (`packages/core/src/models/ServerCredentials.ts`): Accepts optional `{ publicServer?: boolean }` option — sets `serverPassword`/`tvPassword` to `''` when true
- **`OCIServerManager`**: Checks `variantConfig.publicServer` before generating passwords inline
- **`AWSServerManager`**: Passes `variantConfig.publicServer` to `ServerCredentials.generate()`
- **`config/default.json`**: Enabled `"publicServer": true` on `pubstar-casual` and `frisbeeverse` variants
- **Tests**: Added 7 new test cases across `ServerCredentials`, `OCIServerManager`, and `AWSServerManager` test files

## Related

- Closes the issue of casual servers showing passwords in Discord output
- The existing `casual_base.cfg` `sv_password ""` line remains as a defense-in-depth measure