### PR TITLE
refactor(jobs): extract shared job routine helper to eliminate boilerplate

### DIFF
--- a/packages/entrypoints/src/jobs/PendingServerCleanupRoutine.ts
+++ b/packages/entrypoints/src/jobs/PendingServerCleanupRoutine.ts
@@ -1,24 +1,14 @@
-import { logger } from '@tf2qs/telemetry';
-import schedule from 'node-schedule';
 import { TerminatePendingServers } from '@tf2qs/core';
 import { EventLogger } from '@tf2qs/core';
+import { createScheduledRoutine } from './createScheduledRoutine';
 
-// Schedule a job to run every 10 minutes
+// Schedule a job to run every 15 minutes
 export const schedulePendingServerCleanupRoutine = (dependencies: {
     terminatePendingServers: TerminatePendingServers,
     eventLogger: EventLogger
 }) => {
-    schedule.scheduleJob('*/15 * * * *', async () => {
-        try {
-            logger.emit({ severityText: 'INFO', body: 'Running Pending Server Cleanup Routine...' });
-            await dependencies.terminatePendingServers.execute();
-            logger.emit({ severityText: 'INFO', body: 'Pending Server Cleanup Routine completed successfully.' });
-        } catch (error) {
-            logger.emit({ severityText: 'ERROR', body: 'Error during Pending Server Cleanup Routine', attributes: { error: JSON.stringify(error, Object.getOwnPropertyNames(error)) } });
-            await dependencies.eventLogger.log({
-                eventMessage: `Error during Pending Server Cleanup Routine: ${error instanceof Error ? error.message : String(error)}`,
-                actorId: 'system',
-            });
-        }
-    });
-}
+    createScheduledRoutine('*/15 * * * *', 'Pending Server Cleanup Routine', () =>
+        dependencies.terminatePendingServers.execute(),
+        dependencies.eventLogger
+    );
+};

--- a/packages/entrypoints/src/jobs/ServerCleanupRoutine.ts
+++ b/packages/entrypoints/src/jobs/ServerCleanupRoutine.ts
@@ -1,24 +1,14 @@
-import { logger } from '@tf2qs/telemetry';
-import schedule from 'node-schedule';
 import { TerminateEmptyServers } from '@tf2qs/core';
 import { EventLogger } from '@tf2qs/core';
+import { createScheduledRoutine } from './createScheduledRoutine';
 
 // Schedule a job to run every minute
 export const scheduleServerCleanupRoutine = (dependencies: {
     terminateEmptyServers: TerminateEmptyServers,
     eventLogger: EventLogger
 }) => {
-    schedule.scheduleJob('* * * * *', async () => {
-        try {
-            logger.emit({ severityText: 'INFO', body: 'Running Server Cleanup Routine...' });
-            await dependencies.terminateEmptyServers.execute();
-            logger.emit({ severityText: 'INFO', body: 'Server Cleanup Routine completed successfully.' });
-        } catch (error) {
-            logger.emit({ severityText: 'ERROR', body: 'Error during Server Cleanup Routine', attributes: { error: JSON.stringify(error, Object.getOwnPropertyNames(error)) } });
-            await dependencies.eventLogger.log({
-                eventMessage: `Error during Server Cleanup Routine: ${error instanceof Error ? error.message : String(error)}`,
-                actorId: 'system',
-            });
-        }
-    });
-}
+    createScheduledRoutine('* * * * *', 'Server Cleanup Routine', () =>
+        dependencies.terminateEmptyServers.execute(),
+        dependencies.eventLogger
+    );
+};

--- a/packages/entrypoints/src/jobs/TerminateLongRunningServerRoutine.ts
+++ b/packages/entrypoints/src/jobs/TerminateLongRunningServerRoutine.ts
@@ -1,23 +1,13 @@
-import { logger } from '@tf2qs/telemetry';
-import schedule from 'node-schedule';
 import { TerminateLongRunningServers } from '@tf2qs/core';
 import { EventLogger } from '@tf2qs/core';
+import { createScheduledRoutine } from './createScheduledRoutine';
 
 export const scheduleTerminateLongRunningServerRoutine = (dependencies: {
     terminateLongRunningServers: TerminateLongRunningServers,
     eventLogger: EventLogger
 }) => {
-    schedule.scheduleJob('*/30 * * * *', async () => {
-        try {
-            logger.emit({ severityText: 'INFO', body: 'Running Terminate Long Running Server routine...' });
-            await dependencies.terminateLongRunningServers.execute();
-            logger.emit({ severityText: 'INFO', body: 'Terminate Long Running Server routine completed successfully.' });
-        } catch (error) {
-            logger.emit({ severityText: 'ERROR', body: 'Error during Terminate Long Running Server routine', attributes: { error: JSON.stringify(error, Object.getOwnPropertyNames(error)) } });
-            await dependencies.eventLogger.log({
-                eventMessage: `Error during Terminate Long Running Server routine: ${error instanceof Error ? error.message : String(error)}`,
-                actorId: 'system',
-            });
-        }
-    });
+    createScheduledRoutine('*/30 * * * *', 'Terminate Long Running Server routine', () =>
+        dependencies.terminateLongRunningServers.execute(),
+        dependencies.eventLogger
+    );
 };

--- a/packages/entrypoints/src/jobs/createScheduledRoutine.ts
+++ b/packages/entrypoints/src/jobs/createScheduledRoutine.ts
@@ -1,0 +1,28 @@
+import { logger } from '@tf2qs/telemetry';
+import schedule from 'node-schedule';
+import { EventLogger } from '@tf2qs/core';
+
+export function createScheduledRoutine(
+    cronExpression: string,
+    routineName: string,
+    fn: () => Promise<void>,
+    eventLogger: EventLogger
+): void {
+    schedule.scheduleJob(cronExpression, async () => {
+        try {
+            logger.emit({ severityText: 'INFO', body: `Running ${routineName}...` });
+            await fn();
+            logger.emit({ severityText: 'INFO', body: `${routineName} completed successfully.` });
+        } catch (error) {
+            logger.emit({
+                severityText: 'ERROR',
+                body: `Error during ${routineName}`,
+                attributes: { error: JSON.stringify(error, Object.getOwnPropertyNames(error)) },
+            });
+            await eventLogger.log({
+                eventMessage: `Error during ${routineName}: ${error instanceof Error ? error.message : String(error)}`,
+                actorId: 'system',
+            });
+        }
+    });
+}

--- a/packages/entrypoints/src/jobs/index.ts
+++ b/packages/entrypoints/src/jobs/index.ts
@@ -2,3 +2,4 @@ export * from "./ServerCleanupRoutine"
 export * from "./PendingServerCleanupRoutine";
 export * from "./TerminateLongRunningServerRoutine";
 export * from "./MonthlyUsageReportRoutine";
+export * from "./createScheduledRoutine";


### PR DESCRIPTION
## Summary

Extracts a shared `createScheduledRoutine` helper function that encapsulates the common try/catch/log/schedule pattern duplicated across all job routine files.

## Changes

- **New**: `createScheduledRoutine.ts` — reusable helper that schedules a job with consistent logging and error handling
- **Refactored**: `ServerCleanupRoutine.ts` — uses `createScheduledRoutine`
- **Refactored**: `PendingServerCleanupRoutine.ts` — uses `createScheduledRoutine`
- **Refactored**: `TerminateLongRunningServerRoutine.ts` — uses `createScheduledRoutine`
- **Exported**: `createScheduledRoutine` from jobs barrel

## Before/After

Each routine dropped from ~23 lines of boilerplate to ~14 focused lines. No behavior change.

Closes #268

🤖 Generated with [Claude Code](https://claude.com/claude-code)