### PR TITLE
fix: remove hardcoded Discord channel ID from MonthlyReportFormatter

### DIFF
--- a/config/default.json
+++ b/config/default.json
@@ -420,6 +420,7 @@
     "discord": {
         "logChannelId": "1360789887208394851",
         "reportDiscordChannelId": "1378761634889076926",
-        "streamerChannelId": "1467687214350733457"
+        "streamerChannelId": "1467687214350733457",
+        "supportChannelId": "1365408843676520508"
     }
 }

--- a/packages/core/src/domain/DiscordConfig.ts
+++ b/packages/core/src/domain/DiscordConfig.ts
@@ -4,6 +4,7 @@ export type DiscordConfig = {
     logChannelId: string;
     reportDiscordChannelId: string;
     streamerChannelId: string;
+    supportChannelId: string;
 }
 
 export const getDiscordConfig = () => {

--- a/packages/entrypoints/src/jobs/MonthlyUsageReportRoutine.test.ts
+++ b/packages/entrypoints/src/jobs/MonthlyUsageReportRoutine.test.ts
@@ -62,6 +62,7 @@ describe("MonthlyUsageReportRoutine", () => {
             reportDiscordChannelId: reportChannelId,
             logChannelId: "log-channel-id",
             streamerChannelId: "streamer-channel-id",
+            supportChannelId: "1365408843676520508",
         });
 
         const sendFn = vi.fn();

--- a/packages/entrypoints/src/jobs/MonthlyUsageReportRoutine.ts
+++ b/packages/entrypoints/src/jobs/MonthlyUsageReportRoutine.ts
@@ -64,7 +64,7 @@ export const scheduleMonthlyUsageReportRoutine = (
       }
 
       const formatter = new MonthlyReportFormatter();
-      const message = formatter.format(report);
+      const message = formatter.format(report, { supportChannelId: discordConfig.supportChannelId });
 
       await channel.send(message);
 

--- a/packages/providers/src/services/MonthlyReportFormatter.ts
+++ b/packages/providers/src/services/MonthlyReportFormatter.ts
@@ -2,13 +2,17 @@ import { MonthlyUsageReport } from "@tf2qs/core";
 import { getRegionConfig, Region } from "@tf2qs/core";
 
 export class MonthlyReportFormatter {
-  format(report: MonthlyUsageReport): string {
+  format(report: MonthlyUsageReport, options?: { supportChannelId?: string }): string {
     const monthName = this.getMonthName(report.month);
 
     const topUsersSection = this.formatTopUsers(report.topUsers);
     const regionMetricsSection = this.formatRegionMetrics(report.regionMetrics);
     const generalStatsSection = this.formatGeneralStats(report);
     const costsSection = this.formatCostsSection(report.regionCosts);
+
+    const supportLine = options?.supportChannelId
+      ? `\nSee <#${options.supportChannelId}> to help!`
+      : '';
 
     return `@everyone
 📊 **TF2-QuickServer | ${monthName} ${report.year} Metrics & Costs**
@@ -23,8 +27,7 @@ ${topUsersSection}
 ${regionMetricsSection}
 ---
 📈 **General Stats**
-${generalStatsSection}
-See <#1365408843676520508> to help!`;
+${generalStatsSection}${supportLine}`;
   }
 
   private formatCostsSection(regionCosts: Array<{ region: string; cost: number; currency: string }>): string {


### PR DESCRIPTION
Closes #274

## Changes

- **`DiscordConfig`**: Added `supportChannelId` field to the type definition
- **`config/default.json`**: Added `supportChannelId` with the original value (moved out of source code)
- **`MonthlyReportFormatter.format()`**: Now accepts an optional `options.supportChannelId`. The "See <#...> to help!" line is only included when a channel ID is provided
- **`MonthlyUsageReportRoutine`**: Passes `supportChannelId` from `DiscordConfig` to the formatter
- **Tests**: Updated mock to include `supportChannelId`

## Why

The formatter had a hardcoded Discord channel ID, coupling it to a specific infrastructure detail. Anyone self-hosting would see a broken/wrong channel mention in their monthly report. Now the channel ID is externalized to config and passed as an optional parameter.