### PR TITLE
feat: add static landing page for TF2-QuickServer

### DIFF
--- a/landing-page/index.html
+++ b/landing-page/index.html
@@ -54,7 +54,7 @@
       <h1 class="hero-title">TF2-QuickServer</h1>
       <p class="hero-subtitle">Deploy Team Fortress 2 servers directly from Discord.<br />Powered by Docker &mdash; multi-cloud, global, and ready in minutes.</p>
       <div class="hero-cta mt-4">
-        <a href="https://discord.com/oauth2/authorize?client_id=1355639481020977243" class="btn btn-install btn-lg me-3 mb-2" target="_blank" rel="noopener">
+        <a href="https://discord.com/oauth2/authorize?client_id=1355639481020977243&scope=bot%20applications.commands&permissions=0" class="btn btn-install btn-lg me-3 mb-2" target="_blank" rel="noopener">
           <i class="fab fa-discord me-2"></i>Install the Bot
         </a>
         <a href="https://discord.gg/HfDgMj73cW" class="btn btn-discord btn-lg me-3 mb-2" target="_blank" rel="noopener">
@@ -195,9 +195,14 @@
                 <strong>Manage Server</strong> permission, or install it for your own user account
                 to use across all your servers.
               </p>
-              <a href="https://discord.com/oauth2/authorize?client_id=1355639481020977243" class="btn btn-install btn-lg mt-3" target="_blank" rel="noopener">
-                <i class="fab fa-discord me-2"></i>Install on Discord
-              </a>
+              <div class="d-flex flex-wrap justify-content-center gap-3 mt-3">
+                <a href="https://discord.com/oauth2/authorize?client_id=1355639481020977243&scope=bot%20applications.commands&permissions=0&integration_type=0" class="btn btn-install btn-lg" target="_blank" rel="noopener">
+                  <i class="fab fa-discord me-2"></i>Add to Server
+                </a>
+                <a href="https://discord.com/oauth2/authorize?client_id=1355639481020977243&scope=applications.commands&integration_type=1" class="btn btn-outline-light btn-lg" target="_blank" rel="noopener">
+                  <i class="fas fa-user me-2"></i>Install for Me
+                </a>
+              </div>
               <p class="text-muted small mt-3 mb-0">
                 No credit card required. No setup needed. Works immediately after install.
               </p>
@@ -237,7 +242,6 @@
                 <li><span class="fi fi-ar region-flag" title="Argentina"></span> Buenos Aires</li>
                 <li><span class="fi fi-pe region-flag" title="Peru"></span> Lima</li>
               </ul>
-              <p class="text-muted small mt-3 mb-0">The official bot supports these regions. Self-hosted instances can use any OCI or AWS region.</p>
             </div>
           </div>
         </div>
@@ -300,7 +304,7 @@
         <div class="col-md-4">
           <h5>Get Started</h5>
           <ul class="list-unstyled footer-links">
-            <li><a href="https://discord.com/oauth2/authorize?client_id=1355639481020977243" target="_blank" rel="noopener"><i class="fab fa-discord me-2"></i>Install Bot</a></li>
+            <li><a href="https://discord.com/oauth2/authorize?client_id=1355639481020977243&scope=bot%20applications.commands&permissions=0" target="_blank" rel="noopener"><i class="fab fa-discord me-2"></i>Install Bot</a></li>
             <li><a href="https://discord.gg/HfDgMj73cW" target="_blank" rel="noopener"><i class="fab fa-discord me-2"></i>Join Discord</a></li>
             <li><a href="https://github.com/sonikro/TF2-QuickServer/wiki" target="_blank" rel="noopener"><i class="fas fa-book me-2"></i>Wiki</a></li>
             <li><a href="https://status.sonikro.com/" target="_blank" rel="noopener"><i class="fas fa-heart-pulse me-2"></i>Status</a></li>

--- a/landing-page/index.html
+++ b/landing-page/index.html
@@ -1,0 +1,363 @@
+<!doctype html>
+<html lang="en" data-bs-theme="dark">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>TF2-QuickServer — Deploy TF2 Servers from Discord</title>
+  <meta name="description" content="Deploy Team Fortress 2 servers directly from Discord using Docker and multi-cloud infrastructure. Spin up a server in minutes." />
+  <meta property="og:title" content="TF2-QuickServer — Deploy TF2 Servers from Discord" />
+  <meta property="og:description" content="Deploy Team Fortress 2 servers directly from Discord using Docker and multi-cloud infrastructure. Spin up a server in minutes." />
+  <meta property="og:url" content="https://tf2-quickserver.sonikro.com" />
+  <meta property="og:image" content="https://raw.githubusercontent.com/sonikro/TF2-QuickServer/main/assets/logo.png" />
+  <meta property="og:image:width" content="512" />
+  <meta property="og:image:height" content="512" />
+  <meta property="og:type" content="website" />
+  <meta name="twitter:card" content="summary_large_image" />
+  <meta name="twitter:image" content="https://raw.githubusercontent.com/sonikro/TF2-QuickServer/main/assets/logo.png" />
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap" rel="stylesheet" />
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet" />
+  <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css" rel="stylesheet" />
+  <link href="style.css" rel="stylesheet" />
+  <link rel="icon" href="../assets/logo.png" type="image/png" />
+</head>
+<body>
+
+  <!-- Navigation -->
+  <nav class="navbar navbar-expand-lg navbar-dark fixed-top" aria-label="Main navigation">
+    <div class="container">
+      <a class="navbar-brand" href="#">
+        <img src="../assets/logo.png" alt="TF2-QuickServer" height="36" class="d-inline-block align-middle me-2" />
+        <span class="align-middle fw-bold">TF2-QuickServer</span>
+      </a>
+      <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#mainNav">
+        <span class="navbar-toggler-icon"></span>
+      </button>
+      <div class="collapse navbar-collapse" id="mainNav">
+        <ul class="navbar-nav ms-auto">
+          <li class="nav-item"><a class="nav-link" href="#features">Features</a></li>
+          <li class="nav-item"><a class="nav-link" href="#how-it-works">How It Works</a></li>
+          <li class="nav-item"><a class="nav-link" href="#regions">Regions</a></li>
+          <li class="nav-item"><a class="nav-link" href="#commands">Commands</a></li>
+          <li class="nav-item"><a class="nav-link" href="#self-hosting">Self-Host</a></li>
+        </ul>
+      </div>
+    </div>
+  </nav>
+
+  <!-- Hero -->
+  <section id="hero" class="hero d-flex align-items-center">
+    <div class="container text-center">
+      <img src="../assets/logo.png" alt="TF2-QuickServer Logo" class="hero-logo mb-4" />
+      <h1 class="hero-title">TF2-QuickServer</h1>
+      <p class="hero-subtitle">Deploy Team Fortress 2 servers directly from Discord.<br />Powered by Docker &mdash; multi-cloud, global, and ready in minutes.</p>
+      <div class="hero-cta mt-4">
+        <a href="https://discord.gg/HfDgMj73cW" class="btn btn-discord btn-lg me-3 mb-2" target="_blank" rel="noopener">
+          <i class="fab fa-discord me-2"></i>Join Discord
+        </a>
+        <a href="https://github.com/sonikro/TF2-QuickServer" class="btn btn-outline-light btn-lg me-3 mb-2" target="_blank" rel="noopener">
+          <i class="fab fa-github me-2"></i>GitHub
+        </a>
+        <a href="https://github.com/sonikro/TF2-QuickServer/wiki" class="btn btn-outline-light btn-lg mb-2" target="_blank" rel="noopener">
+          <i class="fas fa-book me-2"></i>Wiki
+        </a>
+      </div>
+    </div>
+  </section>
+
+  <!-- Features -->
+  <section id="features" class="section">
+    <div class="container">
+      <h2 class="section-title text-center">Features</h2>
+      <p class="section-subtitle text-center">Everything you need to run TF2 servers at scale</p>
+      <div class="row g-4 mt-3">
+        <div class="col-md-6 col-lg-4">
+          <div class="feature-card card h-100">
+            <div class="card-body text-center p-4">
+              <div class="feature-icon"><i class="fas fa-bolt"></i></div>
+              <h5 class="card-title">Quick Server Deployment</h5>
+              <p class="card-text">Spin up a TF2 server in ~3 minutes with a simple Discord command. No manual configuration needed.</p>
+            </div>
+          </div>
+        </div>
+        <div class="col-md-6 col-lg-4">
+          <div class="feature-card card h-100">
+            <div class="card-body text-center p-4">
+              <div class="feature-icon"><i class="fas fa-globe-americas"></i></div>
+              <h5 class="card-title">Multi-Cloud Global</h5>
+              <p class="card-text">Deploy across Oracle Cloud regions and AWS Local Zones for low-latency gameplay worldwide.</p>
+            </div>
+          </div>
+        </div>
+        <div class="col-md-6 col-lg-4">
+          <div class="feature-card card h-100">
+            <div class="card-body text-center p-4">
+              <div class="feature-icon"><i class="fas fa-shield-halved"></i></div>
+              <h5 class="card-title">DDoS Protection</h5>
+              <p class="card-text">TF2-QuickServer-Shield monitors and blocks attacks in real time with in-game notifications.</p>
+            </div>
+          </div>
+        </div>
+        <div class="col-md-6 col-lg-4">
+          <div class="feature-card card h-100">
+            <div class="card-body text-center p-4">
+              <div class="feature-icon"><i class="fas fa-cubes"></i></div>
+              <h5 class="card-title">Containerized</h5>
+              <p class="card-text">Each server runs in an isolated Docker container with baked-in maps and configs.</p>
+            </div>
+          </div>
+        </div>
+        <div class="col-md-6 col-lg-4">
+          <div class="feature-card card h-100">
+            <div class="card-body text-center p-4">
+              <div class="feature-icon"><i class="fas fa-coins"></i></div>
+              <h5 class="card-title">Auto Cost Savings</h5>
+              <p class="card-text">Idle servers terminate after 10 minutes. Pay only for what you use &mdash; no wasted resources.</p>
+            </div>
+          </div>
+        </div>
+        <div class="col-md-6 col-lg-4">
+          <div class="feature-card card h-100">
+            <div class="card-body text-center p-4">
+              <div class="feature-icon"><i class="fas fa-chart-line"></i></div>
+              <h5 class="card-title">Full Observability</h5>
+              <p class="card-text">OpenTelemetry instrumentation provides traces, metrics, and logs. Optional New Relic sidecar for enhanced infrastructure monitoring.</p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- How It Works -->
+  <section id="how-it-works" class="section bg-section">
+    <div class="container">
+      <h2 class="section-title text-center">How It Works</h2>
+      <p class="section-subtitle text-center">From command to server in five simple steps</p>
+      <div class="row mt-4">
+        <div class="col-lg-10 mx-auto">
+          <div class="step-list">
+            <div class="step">
+              <div class="step-number">1</div>
+              <div class="step-content">
+                <h5>Join the Discord</h5>
+                <p>Join our community or use the bot in a partnered guild.</p>
+              </div>
+            </div>
+            <div class="step">
+              <div class="step-number">2</div>
+              <div class="step-content">
+                <h5>Run <code>/create-server &lt;region&gt;</code></h5>
+                <p>Choose a region near you for the best latency.</p>
+              </div>
+            </div>
+            <div class="step">
+              <div class="step-number">3</div>
+              <div class="step-content">
+                <h5>Select a Variant</h5>
+                <p>Pick a server config like <code>standard-competitive</code> or your custom variant.</p>
+              </div>
+            </div>
+            <div class="step">
+              <div class="step-number">4</div>
+              <div class="step-content">
+                <h5>Receive Connection Info</h5>
+                <p>Get SDR, direct, and STV addresses along with passwords instantly.</p>
+              </div>
+            </div>
+            <div class="step">
+              <div class="step-number">5</div>
+              <div class="step-content">
+                <h5>Connect &amp; Play</h5>
+                <p>Join the server and play. The server auto-terminates after 10 minutes of idle.</p>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- Regions -->
+  <section id="regions" class="section">
+    <div class="container">
+      <h2 class="section-title text-center">Supported Regions</h2>
+      <p class="section-subtitle text-center">Global coverage for low-latency gameplay</p>
+      <div class="row mt-4 g-4">
+        <div class="col-md-6">
+          <div class="card h-100">
+            <div class="card-body p-4">
+              <h5 class="card-title"><i class="fas fa-cloud me-2 text-primary"></i>Oracle Cloud Infrastructure</h5>
+              <ul class="list-unstyled mt-3 region-list">
+                <li><span class="flag-em" title="Chile">&#127470;&#127479;</span> Santiago</li>
+                <li><span class="flag-em" title="Brazil">&#127463;&#127479;</span> S&atilde;o Paulo</li>
+                <li><span class="flag-em" title="Colombia">&#127464;&#127475;</span> Bogot&aacute;</li>
+                <li><span class="flag-em" title="United States">&#127482;&#127480;</span> Chicago</li>
+                <li><span class="flag-em" title="Germany">&#127465;&#127466;</span> Frankfurt</li>
+                <li><span class="flag-em" title="Australia">&#127462;&#127482;</span> Sydney</li>
+              </ul>
+            </div>
+          </div>
+        </div>
+        <div class="col-md-6">
+          <div class="card h-100">
+            <div class="card-body p-4">
+              <h5 class="card-title"><i class="fas fa-cloud me-2 text-warning"></i>AWS Local Zones <span class="badge bg-warning text-dark">Experimental</span></h5>
+              <ul class="list-unstyled mt-3 region-list">
+                <li><span class="flag-em" title="Argentina">&#127462;&#127479;</span> Buenos Aires</li>
+                <li><span class="flag-em" title="Peru">&#127477;&#127466;</span> Lima</li>
+              </ul>
+              <p class="text-muted small mt-3 mb-0">Self-hosters can use any region supporting Oracle Container Instances or AWS ECS Local Zones.</p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- Commands -->
+  <section id="commands" class="section bg-section">
+    <div class="container">
+      <h2 class="section-title text-center">Discord Commands</h2>
+      <p class="section-subtitle text-center">Control everything from your chat</p>
+      <div class="row mt-4">
+        <div class="col-lg-10 mx-auto">
+          <div class="table-responsive">
+            <table class="table table-dark table-striped command-table">
+              <thead>
+                <tr>
+                  <th scope="col">Command</th>
+                  <th scope="col">Description</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td><code>/create-server &lt;region&gt;</code></td>
+                  <td>Launches a server in the selected region (prompts for variant)</td>
+                </tr>
+                <tr>
+                  <td><code>/get-my-servers</code></td>
+                  <td>Retrieves all your active server details (IPs, passwords, etc.)</td>
+                </tr>
+                <tr>
+                  <td><code>/status</code></td>
+                  <td>Shows current status of all servers across all regions</td>
+                </tr>
+                <tr>
+                  <td><code>/terminate-servers</code></td>
+                  <td>Terminates all servers created by the user</td>
+                </tr>
+                <tr>
+                  <td><code>/set-user-data &lt;steamId&gt;</code></td>
+                  <td>Sets SteamID for Sourcemod admin permissions</td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- Self-Hosting -->
+  <section id="self-hosting" class="section">
+    <div class="container">
+      <h2 class="section-title text-center">Self-Hosting</h2>
+      <p class="section-subtitle text-center">Run your own TF2-QuickServer instance</p>
+      <div class="row mt-4 g-4">
+        <div class="col-lg-6">
+          <div class="card h-100">
+            <div class="card-body p-4">
+              <h5 class="card-title"><i class="fas fa-terminal me-2 text-success"></i>Quick Start</h5>
+              <ol class="mt-3">
+                <li class="mb-2">Clone the repo: <code>git clone https://github.com/sonikro/TF2-QuickServer.git</code></li>
+                <li class="mb-2">Configure <code>.env</code> with your tokens
+                  <details class="mt-2">
+                    <summary class="text-muted small">Show .env template</summary>
+                    <pre class="mt-2"><code>DISCORD_TOKEN=
+DISCORD_CLIENT_ID=
+OCI_CONFIG_FILE=
+AWS_ACCESS_KEY_ID=
+AWS_SECRET_ACCESS_KEY=
+DEMOS_TF_APIKEY=
+LOGS_TF_APIKEY=</code></pre>
+                  </details>
+                </li>
+                <li class="mb-2">Install: <code>npm install</code></li>
+                <li class="mb-2">Download maps: <code>npm run download:maps</code></li>
+                <li class="mb-2">Deploy infra: <code>npm run terraform:deploy</code></li>
+                <li class="mb-0">Run: <code>npm run dev</code></li>
+              </ol>
+            </div>
+          </div>
+        </div>
+        <div class="col-lg-6">
+          <div class="card h-100">
+            <div class="card-body p-4">
+              <h5 class="card-title"><i class="fab fa-docker me-2 text-info"></i>Docker Compose</h5>
+              <pre class="mt-3"><code>services:
+  tf2-quickserver:
+    image: sonikro/tf2-quickserver:latest
+    restart: always
+    ports:
+      - 8000:3000
+    env_file:
+      - .env
+    volumes:
+      - ./db:/app/db
+      - ./config:/app/config:ro
+      - ./keys:/app/keys:ro</code></pre>
+              <a href="https://github.com/sonikro/TF2-QuickServer#self-hosting" class="btn btn-outline-light mt-3" target="_blank" rel="noopener">
+                <i class="fas fa-book me-2"></i>Full Guide
+              </a>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- Footer -->
+  <footer class="footer">
+    <div class="container">
+      <div class="row g-4">
+        <div class="col-md-4">
+          <h5><img src="../assets/logo.png" alt="TF2-QuickServer" height="28" class="me-2" />TF2-QuickServer</h5>
+          <p class="text-muted small mt-2">Deploy Team Fortress 2 servers from Discord. Multi-cloud, global, and ready in minutes.</p>
+        </div>
+        <div class="col-md-4">
+          <h5>Links</h5>
+          <ul class="list-unstyled footer-links">
+            <li><a href="https://github.com/sonikro/TF2-QuickServer" target="_blank" rel="noopener"><i class="fab fa-github me-2"></i>GitHub</a></li>
+            <li><a href="https://discord.gg/HfDgMj73cW" target="_blank" rel="noopener"><i class="fab fa-discord me-2"></i>Discord</a></li>
+            <li><a href="https://github.com/sonikro/TF2-QuickServer/wiki" target="_blank" rel="noopener"><i class="fas fa-book me-2"></i>Wiki</a></li>
+            <li><a href="https://status.sonikro.com/" target="_blank" rel="noopener"><i class="fas fa-heart-pulse me-2"></i>Status</a></li>
+          </ul>
+        </div>
+        <div class="col-md-4">
+          <h5>More</h5>
+          <ul class="list-unstyled footer-links">
+            <li><a href="https://github.com/sonikro/TF2-QuickServer/issues" target="_blank" rel="noopener"><i class="fas fa-bug me-2"></i>Issues</a></li>
+            <li><a href="https://github.com/sonikro/TF2-QuickServer#self-hosting" target="_blank" rel="noopener"><i class="fas fa-server me-2"></i>Self-Host</a></li>
+            <li><a href="https://github.com/sonikro/terraform-oracle-tf2-server" target="_blank" rel="noopener"><i class="fas fa-cloud me-2"></i>Terraform Module</a></li>
+            <li><a href="https://github.com/sonikro/TF2-QuickServer/blob/main/docs/api/openapi.yaml" target="_blank" rel="noopener"><i class="fas fa-code me-2"></i>API Spec</a></li>
+          </ul>
+        </div>
+      </div>
+      <hr class="mt-4 mb-3" />
+      <div class="row">
+        <div class="col-md-6 text-center text-md-start">
+          <p class="text-muted small mb-0">&copy; 2025-2026 TF2-QuickServer. MIT License.</p>
+        </div>
+        <div class="col-md-6 text-center text-md-end">
+          <p class="text-muted small mb-0">Logo by <a href="https://www.instagram.com/thecleandesign/" target="_blank" rel="noopener" class="text-muted">kcaugolden</a></p>
+        </div>
+      </div>
+    </div>
+  </footer>
+
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
+  <script src="script.js"></script>
+</body>
+</html>

--- a/landing-page/index.html
+++ b/landing-page/index.html
@@ -19,6 +19,7 @@
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap" rel="stylesheet" />
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet" />
   <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css" rel="stylesheet" />
+  <link href="https://cdn.jsdelivr.net/npm/flag-icons@7.2.3/css/flag-icons.min.css" rel="stylesheet" />
   <link href="style.css" rel="stylesheet" />
   <link rel="icon" href="../assets/logo.png" type="image/png" />
 </head>
@@ -40,7 +41,7 @@
           <li class="nav-item"><a class="nav-link" href="#how-it-works">How It Works</a></li>
           <li class="nav-item"><a class="nav-link" href="#regions">Regions</a></li>
           <li class="nav-item"><a class="nav-link" href="#commands">Commands</a></li>
-          <li class="nav-item"><a class="nav-link" href="#self-hosting">Self-Host</a></li>
+          <li class="nav-item"><a class="nav-link" href="#install">Install Bot</a></li>
         </ul>
       </div>
     </div>
@@ -53,11 +54,11 @@
       <h1 class="hero-title">TF2-QuickServer</h1>
       <p class="hero-subtitle">Deploy Team Fortress 2 servers directly from Discord.<br />Powered by Docker &mdash; multi-cloud, global, and ready in minutes.</p>
       <div class="hero-cta mt-4">
+        <a href="https://discord.com/oauth2/authorize?client_id=1355639481020977243" class="btn btn-install btn-lg me-3 mb-2" target="_blank" rel="noopener">
+          <i class="fab fa-discord me-2"></i>Install the Bot
+        </a>
         <a href="https://discord.gg/HfDgMj73cW" class="btn btn-discord btn-lg me-3 mb-2" target="_blank" rel="noopener">
           <i class="fab fa-discord me-2"></i>Join Discord
-        </a>
-        <a href="https://github.com/sonikro/TF2-QuickServer" class="btn btn-outline-light btn-lg me-3 mb-2" target="_blank" rel="noopener">
-          <i class="fab fa-github me-2"></i>GitHub
         </a>
         <a href="https://github.com/sonikro/TF2-QuickServer/wiki" class="btn btn-outline-light btn-lg mb-2" target="_blank" rel="noopener">
           <i class="fas fa-book me-2"></i>Wiki
@@ -70,7 +71,7 @@
   <section id="features" class="section">
     <div class="container">
       <h2 class="section-title text-center">Features</h2>
-      <p class="section-subtitle text-center">Everything you need to run TF2 servers at scale</p>
+      <p class="section-subtitle text-center">Everything you need to run TF2 servers</p>
       <div class="row g-4 mt-3">
         <div class="col-md-6 col-lg-4">
           <div class="feature-card card h-100">
@@ -141,8 +142,8 @@
             <div class="step">
               <div class="step-number">1</div>
               <div class="step-content">
-                <h5>Join the Discord</h5>
-                <p>Join our community or use the bot in a partnered guild.</p>
+                <h5>Install the Bot</h5>
+                <p>Add TF2-QuickServer to your Discord server with one click.</p>
               </div>
             </div>
             <div class="step">
@@ -179,8 +180,36 @@
     </div>
   </section>
 
+  <!-- Install the Bot -->
+  <section id="install" class="section">
+    <div class="container">
+      <h2 class="section-title text-center">Install the Bot</h2>
+      <p class="section-subtitle text-center">Add TF2-QuickServer to your Discord in seconds</p>
+      <div class="row mt-4 justify-content-center">
+        <div class="col-lg-8">
+          <div class="card install-card">
+            <div class="card-body p-5 text-center">
+              <div class="install-icon mb-4"><i class="fab fa-discord"></i></div>
+              <p class="install-description">
+                You can install TF2-QuickServer in any Discord server where you have the
+                <strong>Manage Server</strong> permission, or install it for your own user account
+                to use across all your servers.
+              </p>
+              <a href="https://discord.com/oauth2/authorize?client_id=1355639481020977243" class="btn btn-install btn-lg mt-3" target="_blank" rel="noopener">
+                <i class="fab fa-discord me-2"></i>Install on Discord
+              </a>
+              <p class="text-muted small mt-3 mb-0">
+                No credit card required. No setup needed. Works immediately after install.
+              </p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+
   <!-- Regions -->
-  <section id="regions" class="section">
+  <section id="regions" class="section bg-section">
     <div class="container">
       <h2 class="section-title text-center">Supported Regions</h2>
       <p class="section-subtitle text-center">Global coverage for low-latency gameplay</p>
@@ -190,12 +219,12 @@
             <div class="card-body p-4">
               <h5 class="card-title"><i class="fas fa-cloud me-2 text-primary"></i>Oracle Cloud Infrastructure</h5>
               <ul class="list-unstyled mt-3 region-list">
-                <li><span class="flag-em" title="Chile">&#127470;&#127479;</span> Santiago</li>
-                <li><span class="flag-em" title="Brazil">&#127463;&#127479;</span> S&atilde;o Paulo</li>
-                <li><span class="flag-em" title="Colombia">&#127464;&#127475;</span> Bogot&aacute;</li>
-                <li><span class="flag-em" title="United States">&#127482;&#127480;</span> Chicago</li>
-                <li><span class="flag-em" title="Germany">&#127465;&#127466;</span> Frankfurt</li>
-                <li><span class="flag-em" title="Australia">&#127462;&#127482;</span> Sydney</li>
+                <li><span class="fi fi-cl region-flag" title="Chile"></span> Santiago</li>
+                <li><span class="fi fi-br region-flag" title="Brazil"></span> S&atilde;o Paulo</li>
+                <li><span class="fi fi-co region-flag" title="Colombia"></span> Bogot&aacute;</li>
+                <li><span class="fi fi-us region-flag" title="United States"></span> Chicago</li>
+                <li><span class="fi fi-de region-flag" title="Germany"></span> Frankfurt</li>
+                <li><span class="fi fi-au region-flag" title="Australia"></span> Sydney</li>
               </ul>
             </div>
           </div>
@@ -205,10 +234,10 @@
             <div class="card-body p-4">
               <h5 class="card-title"><i class="fas fa-cloud me-2 text-warning"></i>AWS Local Zones <span class="badge bg-warning text-dark">Experimental</span></h5>
               <ul class="list-unstyled mt-3 region-list">
-                <li><span class="flag-em" title="Argentina">&#127462;&#127479;</span> Buenos Aires</li>
-                <li><span class="flag-em" title="Peru">&#127477;&#127466;</span> Lima</li>
+                <li><span class="fi fi-ar region-flag" title="Argentina"></span> Buenos Aires</li>
+                <li><span class="fi fi-pe region-flag" title="Peru"></span> Lima</li>
               </ul>
-              <p class="text-muted small mt-3 mb-0">Self-hosters can use any region supporting Oracle Container Instances or AWS ECS Local Zones.</p>
+              <p class="text-muted small mt-3 mb-0">The official bot supports these regions. Self-hosted instances can use any OCI or AWS region.</p>
             </div>
           </div>
         </div>
@@ -217,7 +246,7 @@
   </section>
 
   <!-- Commands -->
-  <section id="commands" class="section bg-section">
+  <section id="commands" class="section">
     <div class="container">
       <h2 class="section-title text-center">Discord Commands</h2>
       <p class="section-subtitle text-center">Control everything from your chat</p>
@@ -260,64 +289,6 @@
     </div>
   </section>
 
-  <!-- Self-Hosting -->
-  <section id="self-hosting" class="section">
-    <div class="container">
-      <h2 class="section-title text-center">Self-Hosting</h2>
-      <p class="section-subtitle text-center">Run your own TF2-QuickServer instance</p>
-      <div class="row mt-4 g-4">
-        <div class="col-lg-6">
-          <div class="card h-100">
-            <div class="card-body p-4">
-              <h5 class="card-title"><i class="fas fa-terminal me-2 text-success"></i>Quick Start</h5>
-              <ol class="mt-3">
-                <li class="mb-2">Clone the repo: <code>git clone https://github.com/sonikro/TF2-QuickServer.git</code></li>
-                <li class="mb-2">Configure <code>.env</code> with your tokens
-                  <details class="mt-2">
-                    <summary class="text-muted small">Show .env template</summary>
-                    <pre class="mt-2"><code>DISCORD_TOKEN=
-DISCORD_CLIENT_ID=
-OCI_CONFIG_FILE=
-AWS_ACCESS_KEY_ID=
-AWS_SECRET_ACCESS_KEY=
-DEMOS_TF_APIKEY=
-LOGS_TF_APIKEY=</code></pre>
-                  </details>
-                </li>
-                <li class="mb-2">Install: <code>npm install</code></li>
-                <li class="mb-2">Download maps: <code>npm run download:maps</code></li>
-                <li class="mb-2">Deploy infra: <code>npm run terraform:deploy</code></li>
-                <li class="mb-0">Run: <code>npm run dev</code></li>
-              </ol>
-            </div>
-          </div>
-        </div>
-        <div class="col-lg-6">
-          <div class="card h-100">
-            <div class="card-body p-4">
-              <h5 class="card-title"><i class="fab fa-docker me-2 text-info"></i>Docker Compose</h5>
-              <pre class="mt-3"><code>services:
-  tf2-quickserver:
-    image: sonikro/tf2-quickserver:latest
-    restart: always
-    ports:
-      - 8000:3000
-    env_file:
-      - .env
-    volumes:
-      - ./db:/app/db
-      - ./config:/app/config:ro
-      - ./keys:/app/keys:ro</code></pre>
-              <a href="https://github.com/sonikro/TF2-QuickServer#self-hosting" class="btn btn-outline-light mt-3" target="_blank" rel="noopener">
-                <i class="fas fa-book me-2"></i>Full Guide
-              </a>
-            </div>
-          </div>
-        </div>
-      </div>
-    </div>
-  </section>
-
   <!-- Footer -->
   <footer class="footer">
     <div class="container">
@@ -327,20 +298,19 @@ LOGS_TF_APIKEY=</code></pre>
           <p class="text-muted small mt-2">Deploy Team Fortress 2 servers from Discord. Multi-cloud, global, and ready in minutes.</p>
         </div>
         <div class="col-md-4">
-          <h5>Links</h5>
+          <h5>Get Started</h5>
           <ul class="list-unstyled footer-links">
-            <li><a href="https://github.com/sonikro/TF2-QuickServer" target="_blank" rel="noopener"><i class="fab fa-github me-2"></i>GitHub</a></li>
-            <li><a href="https://discord.gg/HfDgMj73cW" target="_blank" rel="noopener"><i class="fab fa-discord me-2"></i>Discord</a></li>
+            <li><a href="https://discord.com/oauth2/authorize?client_id=1355639481020977243" target="_blank" rel="noopener"><i class="fab fa-discord me-2"></i>Install Bot</a></li>
+            <li><a href="https://discord.gg/HfDgMj73cW" target="_blank" rel="noopener"><i class="fab fa-discord me-2"></i>Join Discord</a></li>
             <li><a href="https://github.com/sonikro/TF2-QuickServer/wiki" target="_blank" rel="noopener"><i class="fas fa-book me-2"></i>Wiki</a></li>
             <li><a href="https://status.sonikro.com/" target="_blank" rel="noopener"><i class="fas fa-heart-pulse me-2"></i>Status</a></li>
           </ul>
         </div>
         <div class="col-md-4">
-          <h5>More</h5>
+          <h5>Resources</h5>
           <ul class="list-unstyled footer-links">
-            <li><a href="https://github.com/sonikro/TF2-QuickServer/issues" target="_blank" rel="noopener"><i class="fas fa-bug me-2"></i>Issues</a></li>
-            <li><a href="https://github.com/sonikro/TF2-QuickServer#self-hosting" target="_blank" rel="noopener"><i class="fas fa-server me-2"></i>Self-Host</a></li>
-            <li><a href="https://github.com/sonikro/terraform-oracle-tf2-server" target="_blank" rel="noopener"><i class="fas fa-cloud me-2"></i>Terraform Module</a></li>
+            <li><a href="https://github.com/sonikro/TF2-QuickServer/issues" target="_blank" rel="noopener"><i class="fas fa-bug me-2"></i>Report a Bug</a></li>
+            <li><a href="https://github.com/sonikro/TF2-QuickServer" target="_blank" rel="noopener"><i class="fab fa-github me-2"></i>GitHub</a></li>
             <li><a href="https://github.com/sonikro/TF2-QuickServer/blob/main/docs/api/openapi.yaml" target="_blank" rel="noopener"><i class="fas fa-code me-2"></i>API Spec</a></li>
           </ul>
         </div>

--- a/landing-page/script.js
+++ b/landing-page/script.js
@@ -1,0 +1,48 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const nav = document.querySelector('.navbar');
+  const navLinks = document.querySelectorAll('.nav-link');
+  const sections = document.querySelectorAll('section[id]');
+
+  function updateActiveLink() {
+    const navHeight = nav.offsetHeight;
+    let current = '';
+    sections.forEach(section => {
+      const top = section.offsetTop - navHeight - 10;
+      if (window.scrollY >= top) {
+        current = section.getAttribute('id');
+      }
+    });
+    navLinks.forEach(link => {
+      link.classList.remove('active');
+      if (link.getAttribute('href') === '#' + current) {
+        link.classList.add('active');
+      }
+    });
+  }
+
+  navLinks.forEach(link => {
+    link.addEventListener('click', e => {
+      const target = document.querySelector(link.getAttribute('href'));
+      if (target) {
+        e.preventDefault();
+        const navbarCollapse = document.querySelector('.navbar-collapse');
+        if (navbarCollapse.classList.contains('show')) {
+          bootstrap.Collapse.getInstance(navbarCollapse).hide();
+        }
+        target.scrollIntoView({ behavior: 'smooth', block: 'start' });
+      }
+    });
+  });
+
+  if (window.location.hash) {
+    const target = document.querySelector(window.location.hash);
+    if (target) {
+      setTimeout(() => {
+        target.scrollIntoView({ behavior: 'smooth', block: 'start' });
+      }, 100);
+    }
+  }
+
+  window.addEventListener('scroll', updateActiveLink, { passive: true });
+  updateActiveLink();
+});

--- a/landing-page/style.css
+++ b/landing-page/style.css
@@ -1,0 +1,342 @@
+:root {
+  --accent: #f39c12;
+  --accent-rgb: 243, 156, 18;
+  --accent-hover: #e67e22;
+  --dark-bg: #0d1117;
+  --section-bg: #161b22;
+  --card-bg: #1c2333;
+  --text-muted: #8b949e;
+}
+
+* {
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
+}
+
+body {
+  font-family: 'Inter', -apple-system, BlinkMacSystemFont, sans-serif;
+  background-color: var(--dark-bg);
+  color: #e6edf3;
+  padding-top: 72px;
+}
+
+/* Navbar */
+.navbar {
+  background-color: rgba(13, 17, 23, 0.92);
+  backdrop-filter: blur(12px);
+  border-bottom: 1px solid rgba(255, 255, 255, 0.06);
+  padding: 12px 0;
+}
+
+.navbar-brand {
+  font-size: 1.2rem;
+  letter-spacing: -0.01em;
+}
+
+.nav-link {
+  font-size: 0.9rem;
+  font-weight: 500;
+  padding: 8px 16px !important;
+  border-radius: 8px;
+  transition: background 0.2s;
+}
+
+.nav-link:hover {
+  background: rgba(255, 255, 255, 0.06);
+}
+
+/* Hero */
+.hero {
+  min-height: calc(100vh - 72px);
+  background: linear-gradient(135deg, #0d1117 0%, #162033 50%, #0d1117 100%);
+  position: relative;
+  overflow: hidden;
+}
+
+.hero::before {
+  content: '';
+  position: absolute;
+  top: -50%;
+  left: -50%;
+  width: 200%;
+  height: 200%;
+  background: radial-gradient(circle at 30% 50%, rgba(243, 156, 18, 0.04) 0%, transparent 50%);
+  pointer-events: none;
+}
+
+.hero-logo {
+  width: 140px;
+  height: auto;
+  filter: drop-shadow(0 0 30px rgba(243, 156, 18, 0.2));
+}
+
+.hero-title {
+  font-size: 3.5rem;
+  font-weight: 800;
+  letter-spacing: -0.03em;
+  color: #f39c12;
+  background: linear-gradient(135deg, #f39c12, #e67e22);
+  -webkit-background-clip: text;
+  background-clip: text;
+  -webkit-text-fill-color: transparent;
+  margin-bottom: 0.5rem;
+}
+
+.hero-subtitle {
+  font-size: 1.2rem;
+  color: var(--text-muted);
+  max-width: 600px;
+  margin: 0 auto;
+  line-height: 1.7;
+}
+
+.hero-cta .btn {
+  font-weight: 600;
+  padding: 12px 28px;
+  border-radius: 12px;
+}
+
+.btn-discord {
+  background: #5865f2;
+  border-color: #5865f2;
+  color: #fff;
+}
+
+.btn-discord:hover {
+  background: #4752c4;
+  border-color: #4752c4;
+  color: #fff;
+}
+
+/* Sections */
+.section {
+  padding: 96px 0;
+}
+
+.bg-section {
+  background: var(--section-bg);
+}
+
+.section-title {
+  font-size: 2.2rem;
+  font-weight: 700;
+  letter-spacing: -0.02em;
+  margin-bottom: 0.75rem;
+}
+
+.section-subtitle {
+  font-size: 1.1rem;
+  color: var(--text-muted);
+  max-width: 500px;
+  margin: 0 auto;
+}
+
+/* Feature Cards */
+.feature-card {
+  background: var(--card-bg);
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  border-radius: 16px;
+  transition: transform 0.25s ease, border-color 0.25s ease;
+}
+
+.feature-card:hover {
+  transform: translateY(-4px);
+  border-color: rgba(243, 156, 18, 0.3);
+}
+
+.feature-icon {
+  width: 56px;
+  height: 56px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  margin: 0 auto 16px;
+  background: rgba(243, 156, 18, 0.1);
+  border-radius: 14px;
+  font-size: 1.4rem;
+  color: var(--accent);
+}
+
+/* Steps */
+.step-list {
+  display: flex;
+  flex-direction: column;
+  gap: 0;
+}
+
+.step {
+  display: flex;
+  align-items: flex-start;
+  gap: 20px;
+  padding: 20px 24px;
+  border-left: 2px solid rgba(243, 156, 18, 0.2);
+  position: relative;
+  transition: background 0.2s;
+  border-radius: 0 12px 12px 0;
+}
+
+.step:hover {
+  background: rgba(243, 156, 18, 0.03);
+}
+
+.step:last-child::after {
+  content: '';
+  position: absolute;
+  bottom: 0;
+  left: -2px;
+  width: 2px;
+  height: 40px;
+  background: linear-gradient(to bottom, transparent, var(--dark-bg));
+  pointer-events: none;
+}
+
+.step-number {
+  width: 40px;
+  height: 40px;
+  min-width: 40px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: linear-gradient(135deg, #f39c12, #e67e22);
+  color: #000;
+  font-weight: 700;
+  font-size: 1rem;
+  border-radius: 50%;
+  position: relative;
+  z-index: 1;
+}
+
+.step-content h5 {
+  font-weight: 600;
+  margin-bottom: 4px;
+}
+
+.step-content p {
+  margin: 0;
+  color: var(--text-muted);
+}
+
+.step-content code {
+  background: rgba(243, 156, 18, 0.12);
+  color: var(--accent);
+  padding: 2px 8px;
+  border-radius: 4px;
+  font-size: 0.85em;
+}
+
+/* Regions */
+.region-list li {
+  padding: 8px 0;
+  font-size: 1rem;
+}
+
+.flag-em {
+  display: inline-block;
+  width: 28px;
+  font-size: 1.2rem;
+}
+
+/* Commands */
+.command-table {
+  border-radius: 12px;
+  overflow: hidden;
+}
+
+.command-table thead th {
+  background: rgba(243, 156, 18, 0.1);
+  color: var(--accent);
+  border-bottom: 2px solid rgba(243, 156, 18, 0.2);
+  font-weight: 600;
+}
+
+.command-table code {
+  background: rgba(243, 156, 18, 0.12);
+  color: var(--accent);
+  padding: 2px 8px;
+  border-radius: 4px;
+  font-size: 0.85em;
+  white-space: nowrap;
+}
+
+/* Self-Hosting */
+pre {
+  background: rgba(0, 0, 0, 0.3);
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  border-radius: 10px;
+  padding: 16px;
+  font-size: 0.8rem;
+  overflow-x: auto;
+}
+
+pre code {
+  color: #c9d1d9;
+}
+
+/* Footer */
+.footer {
+  background: #0a0e14;
+  border-top: 1px solid rgba(255, 255, 255, 0.06);
+  padding: 48px 0 32px;
+}
+
+.footer h5 {
+  font-size: 1rem;
+  font-weight: 600;
+  margin-bottom: 16px;
+}
+
+.footer-links li {
+  margin-bottom: 8px;
+}
+
+.footer-links a {
+  color: var(--text-muted);
+  text-decoration: none;
+  font-size: 0.9rem;
+  transition: color 0.2s;
+}
+
+.footer-links a:hover {
+  color: var(--accent);
+}
+
+/* Responsive */
+@media (max-width: 768px) {
+  .hero-title {
+    font-size: 2.2rem;
+  }
+
+  .hero-subtitle {
+    font-size: 1rem;
+  }
+
+  .hero-logo {
+    width: 100px;
+  }
+
+  .section {
+    padding: 64px 0;
+  }
+
+  .section-title {
+    font-size: 1.7rem;
+  }
+
+  .hero-cta .btn {
+    display: block;
+    width: 100%;
+    margin-right: 0 !important;
+  }
+}
+
+@media (max-width: 576px) {
+  pre {
+    font-size: 0.7rem;
+    padding: 12px;
+  }
+
+  .region-list li {
+    font-size: 0.9rem;
+  }
+}

--- a/landing-page/style.css
+++ b/landing-page/style.css
@@ -109,6 +109,18 @@ body {
   color: #fff;
 }
 
+.btn-install {
+  background: #2ea043;
+  border-color: #2ea043;
+  color: #fff;
+}
+
+.btn-install:hover {
+  background: #238636;
+  border-color: #238636;
+  color: #fff;
+}
+
 /* Sections */
 .section {
   padding: 96px 0;
@@ -187,7 +199,7 @@ body {
   left: -2px;
   width: 2px;
   height: 40px;
-  background: linear-gradient(to bottom, transparent, var(--dark-bg));
+  background: linear-gradient(to bottom, transparent, var(--section-bg));
   pointer-events: none;
 }
 
@@ -229,12 +241,17 @@ body {
 .region-list li {
   padding: 8px 0;
   font-size: 1rem;
+  display: flex;
+  align-items: center;
+  gap: 10px;
 }
 
-.flag-em {
-  display: inline-block;
-  width: 28px;
-  font-size: 1.2rem;
+.region-flag {
+  width: 28px !important;
+  height: 20px !important;
+  border-radius: 3px;
+  box-shadow: 0 1px 3px rgba(0,0,0,0.4);
+  flex-shrink: 0;
 }
 
 /* Commands */
@@ -259,18 +276,24 @@ body {
   white-space: nowrap;
 }
 
-/* Self-Hosting */
-pre {
-  background: rgba(0, 0, 0, 0.3);
-  border: 1px solid rgba(255, 255, 255, 0.06);
-  border-radius: 10px;
-  padding: 16px;
-  font-size: 0.8rem;
-  overflow-x: auto;
+/* Install */
+.install-card {
+  background: var(--card-bg);
+  border: 1px solid rgba(46, 160, 67, 0.2);
+  border-radius: 16px;
 }
 
-pre code {
-  color: #c9d1d9;
+.install-icon {
+  font-size: 3rem;
+  color: #2ea043;
+}
+
+.install-description {
+  font-size: 1.1rem;
+  color: var(--text-muted);
+  max-width: 500px;
+  margin: 0 auto;
+  line-height: 1.7;
 }
 
 /* Footer */


### PR DESCRIPTION
A static landing page for TF2-QuickServer, built with plain HTML, CSS, and JavaScript. Bootstrap 5, Font Awesome, and flag-icons loaded via CDN.

**What's included:**

- Hero section with Install Bot, Join Discord, and Wiki CTAs
- Features section (quick deployment, multi-cloud, DDoS protection, containerized, cost savings, observability)
- How It Works guide (5 steps from install to playing)
- Install the Bot section with two install options: Add to Server (guild install) and Install for Me (user install)
- Supported Regions table (OCI + AWS) with flag icons
- Discord Commands reference table
- Footer with links to Install Bot, Discord, Wiki, Status, Issues, GitHub, and API Spec

**Install links use proper Discord OAuth2 scopes and permissions.**