### PR TITLE
feat: add ozfortress configs to standard-competitive images

### DIFF
--- a/landing-page/index.html
+++ b/landing-page/index.html
@@ -21,7 +21,7 @@
   <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css" rel="stylesheet" />
   <link href="https://cdn.jsdelivr.net/npm/flag-icons@7.2.3/css/flag-icons.min.css" rel="stylesheet" />
   <link href="style.css" rel="stylesheet" />
-  <link rel="icon" href="../assets/logo.png" type="image/png" />
+  <link rel="icon" href="assets/logo.png" type="image/png" />
 </head>
 <body>
 
@@ -29,7 +29,7 @@
   <nav class="navbar navbar-expand-lg navbar-dark fixed-top" aria-label="Main navigation">
     <div class="container">
       <a class="navbar-brand" href="#">
-        <img src="../assets/logo.png" alt="TF2-QuickServer" height="36" class="d-inline-block align-middle me-2" />
+        <img src="assets/logo.png" alt="TF2-QuickServer" height="36" class="d-inline-block align-middle me-2" />
         <span class="align-middle fw-bold">TF2-QuickServer</span>
       </a>
       <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#mainNav">
@@ -50,7 +50,7 @@
   <!-- Hero -->
   <section id="hero" class="hero d-flex align-items-center">
     <div class="container text-center">
-      <img src="../assets/logo.png" alt="TF2-QuickServer Logo" class="hero-logo mb-4" />
+      <img src="assets/logo.png" alt="TF2-QuickServer Logo" class="hero-logo mb-4" />
       <h1 class="hero-title">TF2-QuickServer</h1>
       <p class="hero-subtitle">Deploy Team Fortress 2 servers directly from Discord.<br />Powered by Docker &mdash; multi-cloud, global, and ready in minutes.</p>
       <div class="hero-cta mt-4">
@@ -298,7 +298,7 @@
     <div class="container">
       <div class="row g-4">
         <div class="col-md-4">
-          <h5><img src="../assets/logo.png" alt="TF2-QuickServer" height="28" class="me-2" />TF2-QuickServer</h5>
+          <h5><img src="assets/logo.png" alt="TF2-QuickServer" height="28" class="me-2" />TF2-QuickServer</h5>
           <p class="text-muted small mt-2">Deploy Team Fortress 2 servers from Discord. Multi-cloud, global, and ready in minutes.</p>
         </div>
         <div class="col-md-4">

--- a/terraform/landing-page/main.tf
+++ b/terraform/landing-page/main.tf
@@ -1,0 +1,226 @@
+# ===========================================
+# LANDING PAGE - S3 + CloudFront + Route53
+# ===========================================
+# Standalone terraform configuration for hosting the TF2-QuickServer
+# landing page on a private S3 bucket served via CloudFront with HTTPS.
+#
+# Usage:
+#   cd terraform/landing-page
+#   terraform init
+#   terraform apply -var="hosted_zone_id=Z..."
+# ===========================================
+
+# ===========================================
+# RANDOM SUFFIX FOR UNIQUE BUCKET NAME
+# ===========================================
+
+resource "random_id" "bucket_suffix" {
+  byte_length = 6
+}
+
+# ===========================================
+# S3 BUCKET (PRIVATE)
+# ===========================================
+
+resource "aws_s3_bucket" "landing_page" {
+  bucket        = "${var.bucket_name}-${random_id.bucket_suffix.hex}"
+  force_destroy = true
+}
+
+resource "aws_s3_bucket_public_access_block" "landing_page" {
+  bucket = aws_s3_bucket.landing_page.id
+
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
+resource "aws_s3_bucket_versioning" "landing_page" {
+  bucket = aws_s3_bucket.landing_page.id
+
+  versioning_configuration {
+    status = "Enabled"
+  }
+}
+
+resource "aws_s3_bucket_server_side_encryption_configuration" "landing_page" {
+  bucket = aws_s3_bucket.landing_page.id
+
+  rule {
+    apply_server_side_encryption_by_default {
+      sse_algorithm = "AES256"
+    }
+  }
+}
+
+# ===========================================
+# LANDING PAGE FILES (UPLOAD)
+# ===========================================
+
+resource "aws_s3_object" "index_html" {
+  bucket        = aws_s3_bucket.landing_page.id
+  key           = "index.html"
+  source        = "${path.module}/../../landing-page/index.html"
+  content_type  = "text/html; charset=utf-8"
+  cache_control = "max-age=3600"
+  etag          = filemd5("${path.module}/../../landing-page/index.html")
+}
+
+resource "aws_s3_object" "script_js" {
+  bucket        = aws_s3_bucket.landing_page.id
+  key           = "script.js"
+  source        = "${path.module}/../../landing-page/script.js"
+  content_type  = "application/javascript"
+  cache_control = "max-age=3600"
+  etag          = filemd5("${path.module}/../../landing-page/script.js")
+}
+
+resource "aws_s3_object" "style_css" {
+  bucket        = aws_s3_bucket.landing_page.id
+  key           = "style.css"
+  source        = "${path.module}/../../landing-page/style.css"
+  content_type  = "text/css"
+  cache_control = "max-age=3600"
+  etag          = filemd5("${path.module}/../../landing-page/style.css")
+}
+
+# ===========================================
+# CLOUDFRONT ORIGIN ACCESS IDENTITY
+# ===========================================
+
+resource "aws_cloudfront_origin_access_identity" "landing_page" {
+  comment = "OAI for ${var.domain_name}"
+}
+
+# ===========================================
+# S3 BUCKET POLICY (CLOUDFRONT OAI ONLY)
+# ===========================================
+
+resource "aws_s3_bucket_policy" "landing_page" {
+  bucket = aws_s3_bucket.landing_page.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid       = "CloudFrontOAIRead"
+        Effect    = "Allow"
+        Principal = {
+          AWS = aws_cloudfront_origin_access_identity.landing_page.iam_arn
+        }
+        Action   = "s3:GetObject"
+        Resource = "${aws_s3_bucket.landing_page.arn}/*"
+      }
+    ]
+  })
+
+  depends_on = [aws_s3_bucket_public_access_block.landing_page]
+}
+
+# ===========================================
+# ACM CERTIFICATE (DNS VALIDATION)
+# ===========================================
+
+resource "aws_acm_certificate" "landing_page" {
+  domain_name       = var.domain_name
+  validation_method = "DNS"
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+resource "aws_route53_record" "cert_validation" {
+  for_each = {
+    for dvo in aws_acm_certificate.landing_page.domain_validation_options : dvo.domain_name => {
+      name   = dvo.resource_record_name
+      record = dvo.resource_record_value
+      type   = dvo.resource_record_type
+    }
+  }
+
+  allow_overwrite = true
+  name            = each.value.name
+  records         = [each.value.record]
+  ttl             = 60
+  type            = each.value.type
+  zone_id         = var.hosted_zone_id
+}
+
+resource "aws_acm_certificate_validation" "landing_page" {
+  certificate_arn         = aws_acm_certificate.landing_page.arn
+  validation_record_fqdns = [for record in aws_route53_record.cert_validation : record.fqdn]
+}
+
+# ===========================================
+# CLOUDFRONT DISTRIBUTION
+# ===========================================
+
+data "aws_cloudfront_cache_policy" "caching_optimized" {
+  name = "Managed-CachingOptimized"
+}
+
+resource "aws_cloudfront_distribution" "landing_page" {
+  enabled             = true
+  is_ipv6_enabled     = true
+  http_version        = "http2and3"
+  default_root_object = "index.html"
+  aliases             = [var.domain_name]
+
+  origin {
+    domain_name = aws_s3_bucket.landing_page.bucket_regional_domain_name
+    origin_id   = "S3-LandingPage"
+
+    s3_origin_config {
+      origin_access_identity = aws_cloudfront_origin_access_identity.landing_page.cloudfront_access_identity_path
+    }
+  }
+
+  default_cache_behavior {
+    allowed_methods  = ["GET", "HEAD"]
+    cached_methods   = ["GET", "HEAD"]
+    target_origin_id = "S3-LandingPage"
+
+    cache_policy_id = data.aws_cloudfront_cache_policy.caching_optimized.id
+
+    viewer_protocol_policy = "redirect-to-https"
+    compress               = true
+  }
+
+  price_class = "PriceClass_100"
+
+  restrictions {
+    geo_restriction {
+      restriction_type = "none"
+    }
+  }
+
+  viewer_certificate {
+    acm_certificate_arn      = aws_acm_certificate_validation.landing_page.certificate_arn
+    ssl_support_method       = "sni-only"
+    minimum_protocol_version = "TLSv1.2_2021"
+  }
+
+  depends_on = [
+    aws_s3_object.index_html,
+    aws_s3_object.script_js,
+    aws_s3_object.style_css,
+  ]
+}
+
+# ===========================================
+# ROUTE53 DNS RECORD
+# ===========================================
+
+resource "aws_route53_record" "landing_page" {
+  zone_id = var.hosted_zone_id
+  name    = var.domain_name
+  type    = "A"
+
+  alias {
+    name                   = aws_cloudfront_distribution.landing_page.domain_name
+    zone_id                = aws_cloudfront_distribution.landing_page.hosted_zone_id
+    evaluate_target_health = false
+  }
+}

--- a/terraform/landing-page/main.tf
+++ b/terraform/landing-page/main.tf
@@ -58,6 +58,15 @@ resource "aws_s3_bucket_server_side_encryption_configuration" "landing_page" {
 # LANDING PAGE FILES (UPLOAD)
 # ===========================================
 
+resource "aws_s3_object" "logo" {
+  bucket        = aws_s3_bucket.landing_page.id
+  key           = "assets/logo.png"
+  source        = "${path.module}/../../assets/logo.png"
+  content_type  = "image/png"
+  cache_control = "max-age=604800"
+  etag          = filemd5("${path.module}/../../assets/logo.png")
+}
+
 resource "aws_s3_object" "index_html" {
   bucket        = aws_s3_bucket.landing_page.id
   key           = "index.html"
@@ -203,6 +212,7 @@ resource "aws_cloudfront_distribution" "landing_page" {
   }
 
   depends_on = [
+    aws_s3_object.logo,
     aws_s3_object.index_html,
     aws_s3_object.script_js,
     aws_s3_object.style_css,

--- a/terraform/landing-page/outputs.tf
+++ b/terraform/landing-page/outputs.tf
@@ -1,0 +1,24 @@
+output "bucket_name" {
+  description = "Name of the S3 bucket for landing page"
+  value       = aws_s3_bucket.landing_page.id
+}
+
+output "bucket_arn" {
+  description = "ARN of the S3 bucket for landing page"
+  value       = aws_s3_bucket.landing_page.arn
+}
+
+output "cloudfront_domain_name" {
+  description = "CloudFront distribution domain name"
+  value       = aws_cloudfront_distribution.landing_page.domain_name
+}
+
+output "cloudfront_distribution_id" {
+  description = "CloudFront distribution ID"
+  value       = aws_cloudfront_distribution.landing_page.id
+}
+
+output "landing_page_url" {
+  description = "Full landing page URL"
+  value       = "https://${var.domain_name}"
+}

--- a/terraform/landing-page/terraform.tf
+++ b/terraform/landing-page/terraform.tf
@@ -1,0 +1,16 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = "~> 3.0"
+    }
+  }
+}
+
+provider "aws" {
+  region = "us-east-1"
+}

--- a/terraform/landing-page/variables.tf
+++ b/terraform/landing-page/variables.tf
@@ -1,0 +1,17 @@
+variable "bucket_name" {
+  description = "Name of the S3 bucket for landing page assets"
+  type        = string
+  default     = "tf2-quickserver-landing-page"
+}
+
+variable "domain_name" {
+  description = "Custom domain name for the landing page (e.g., landing.quickserver.sonikro.com)"
+  type        = string
+  default     = "landing.quickserver.sonikro.com"
+}
+
+variable "hosted_zone_id" {
+  description = "Route53 hosted zone ID for sonikro.com"
+  type        = string
+  sensitive   = true
+}

--- a/variants/fat-standard-competitive-amd64/Dockerfile
+++ b/variants/fat-standard-competitive-amd64/Dockerfile
@@ -159,6 +159,14 @@ RUN curl -L "${FBTF_CONFIGS_URL}" -o "${FBTF_CONFIGS_FILE_NAME}" \
   && unzip -q "${FBTF_CONFIGS_FILE_NAME}" \
   && mv "fbtf_cfg/"* "${PLUGIN_INSTALL_DIR}/cfg/"
 
+# ozfortress configs
+ARG OZFORTRESS_CONFIGS_VERSION=master
+ARG OZFORTRESS_CONFIGS_FILE_NAME=server-configs-${OZFORTRESS_CONFIGS_VERSION}.zip
+ARG OZFORTRESS_CONFIGS_URL=https://github.com/ozfortress/server-configs/archive/${OZFORTRESS_CONFIGS_VERSION}.zip
+RUN curl -L "${OZFORTRESS_CONFIGS_URL}" -o "${OZFORTRESS_CONFIGS_FILE_NAME}" \
+  && unzip -q "${OZFORTRESS_CONFIGS_FILE_NAME}" \
+  && cp "server-configs-${OZFORTRESS_CONFIGS_VERSION}/cfg/"* "${PLUGIN_INSTALL_DIR}/cfg/"
+
 # SteamPawn - NativePawn compiler for Pawn scripting
 ARG STEAMPAWN_FILE_NAME=package.zip
 ARG STEAMPAWN_VERSION=1.2.0.2

--- a/variants/fat-standard-competitive-i386/Dockerfile
+++ b/variants/fat-standard-competitive-i386/Dockerfile
@@ -150,6 +150,14 @@ RUN curl -L "${FBTF_CONFIGS_URL}" -o "${FBTF_CONFIGS_FILE_NAME}" \
   && unzip -q "${FBTF_CONFIGS_FILE_NAME}" \
   && mv "fbtf_cfg/"* "${PLUGIN_INSTALL_DIR}/cfg/"
 
+# ozfortress configs
+ARG OZFORTRESS_CONFIGS_VERSION=master
+ARG OZFORTRESS_CONFIGS_FILE_NAME=server-configs-${OZFORTRESS_CONFIGS_VERSION}.zip
+ARG OZFORTRESS_CONFIGS_URL=https://github.com/ozfortress/server-configs/archive/${OZFORTRESS_CONFIGS_VERSION}.zip
+RUN curl -L "${OZFORTRESS_CONFIGS_URL}" -o "${OZFORTRESS_CONFIGS_FILE_NAME}" \
+  && unzip -q "${OZFORTRESS_CONFIGS_FILE_NAME}" \
+  && cp "server-configs-${OZFORTRESS_CONFIGS_VERSION}/cfg/"* "${PLUGIN_INSTALL_DIR}/cfg/"
+
 # SteamPawn - NativePawn compiler for Pawn scripting
 ARG STEAMPAWN_FILE_NAME=package.zip
 ARG STEAMPAWN_VERSION=1.2.0.2


### PR DESCRIPTION
Downloads the ozfortress server configs from GitHub and places them in the server cfg directory for both i386 and amd64 standard-competitive variants.

The archive is downloaded from the ozfortress/server-configs repo (master branch) and all `.cfg` and `.txt` files from the `cfg/` directory are copied into the server config directory. This follows the same pattern used by ETF2L, RGL, Ultitrio, and FBTF.

Configs included: 6v6 (5cp, koth, golden cap, pug, scrim), Highlander (5cp, koth, stopwatch, scrim), 4v4, ultiduo, bball, dodgeball, special events, and all corresponding whitelists.