### PR TITLE
feat: add Terragrunt pipeline for landing page deployment via GitHub Actions

### DIFF
--- a/.github/workflows/deploy-landing-page.yaml
+++ b/.github/workflows/deploy-landing-page.yaml
@@ -35,6 +35,11 @@ jobs:
           role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
           aws-region: us-east-1
 
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: "1.9.8"
+
       - name: Setup Terragrunt
         run: |
           TG_VERSION="0.72.6"
@@ -65,6 +70,11 @@ jobs:
         with:
           role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
           aws-region: us-east-1
+
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: "1.9.8"
 
       - name: Setup Terragrunt
         run: |

--- a/.github/workflows/deploy-landing-page.yaml
+++ b/.github/workflows/deploy-landing-page.yaml
@@ -26,6 +26,7 @@ permissions:
 jobs:
   validate:
     runs-on: ubuntu-latest
+    environment: landing-page-prod
     steps:
       - uses: actions/checkout@v4
 
@@ -62,6 +63,7 @@ jobs:
     needs: validate
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
+    environment: landing-page-prod
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/deploy-landing-page.yaml
+++ b/.github/workflows/deploy-landing-page.yaml
@@ -1,0 +1,85 @@
+name: Deploy Landing Page
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - "landing-page/**"
+      - "terraform/landing-page/**"
+      - ".github/workflows/deploy-landing-page.yaml"
+      - "assets/**"
+  pull_request:
+    branches:
+      - main
+    paths:
+      - "landing-page/**"
+      - "terraform/landing-page/**"
+      - ".github/workflows/deploy-landing-page.yaml"
+      - "assets/**"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v5
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
+          aws-region: us-east-1
+
+      - name: Setup Terragrunt
+        run: |
+          TG_VERSION="0.72.6"
+          curl -sL "https://github.com/gruntwork-io/terragrunt/releases/download/v${TG_VERSION}/terragrunt_linux_amd64" -o /usr/local/bin/terragrunt
+          chmod +x /usr/local/bin/terragrunt
+
+      - name: Terragrunt Init
+        working-directory: terraform/landing-page
+        run: terragrunt init
+        env:
+          TF_VAR_hosted_zone_id: ${{ secrets.HOSTED_ZONE_ID }}
+
+      - name: Terragrunt Validate
+        working-directory: terraform/landing-page
+        run: terragrunt validate
+        env:
+          TF_VAR_hosted_zone_id: ${{ secrets.HOSTED_ZONE_ID }}
+
+  apply:
+    needs: validate
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v5
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
+          aws-region: us-east-1
+
+      - name: Setup Terragrunt
+        run: |
+          TG_VERSION="0.72.6"
+          curl -sL "https://github.com/gruntwork-io/terragrunt/releases/download/v${TG_VERSION}/terragrunt_linux_amd64" -o /usr/local/bin/terragrunt
+          chmod +x /usr/local/bin/terragrunt
+
+      - name: Terragrunt Init
+        working-directory: terraform/landing-page
+        run: terragrunt init
+        env:
+          TF_VAR_hosted_zone_id: ${{ secrets.HOSTED_ZONE_ID }}
+
+      - name: Terragrunt Apply
+        working-directory: terraform/landing-page
+        run: terragrunt apply -auto-approve
+        env:
+          TF_VAR_hosted_zone_id: ${{ secrets.HOSTED_ZONE_ID }}

--- a/.gitignore
+++ b/.gitignore
@@ -217,6 +217,9 @@ override.tf.json
 .terraformrc
 terraform.rc
 
+# Terragrunt generated provider files
+provider-generated.tf
+
 # End of https://www.toptal.com/developers/gitignore/api/terraform
 
 # Created by https://www.toptal.com/developers/gitignore/api/go

--- a/terraform/landing-page/terraform.tf
+++ b/terraform/landing-page/terraform.tf
@@ -9,8 +9,6 @@ terraform {
       version = "~> 3.0"
     }
   }
-}
 
-provider "aws" {
-  region = "us-east-1"
+  backend "s3" {}
 }

--- a/terraform/landing-page/terragrunt.hcl
+++ b/terraform/landing-page/terragrunt.hcl
@@ -2,8 +2,6 @@ locals {
   aws_region = "us-east-1"
 }
 
-terraform_version_constraint = ">= 1.8, < 2.0"
-
 remote_state {
   backend = "s3"
   config = {

--- a/terraform/landing-page/terragrunt.hcl
+++ b/terraform/landing-page/terragrunt.hcl
@@ -1,0 +1,26 @@
+locals {
+  aws_region = "us-east-1"
+}
+
+terraform_version_constraint = ">= 1.8, < 2.0"
+
+remote_state {
+  backend = "s3"
+  config = {
+    bucket         = "tf2-quickserver-terraform-state"
+    key            = "landing-page/terraform.tfstate"
+    region         = local.aws_region
+    encrypt        = true
+    dynamodb_table = "tf2-quickserver-terraform-locks"
+  }
+}
+
+generate "provider" {
+  path      = "provider-generated.tf"
+  if_exists = "overwrite_terragrunt"
+  contents  = <<EOF
+provider "aws" {
+  region = "${local.aws_region}"
+}
+EOF
+}


### PR DESCRIPTION
Add a GitHub Actions workflow to deploy the landing page using Terragrunt with S3 remote state and AWS OIDC authentication.

## Changes

- **`.github/workflows/deploy-landing-page.yaml`** - New workflow with two jobs:
  - `validate` - Runs `terragrunt init` and `terragrunt validate` on PRs and pushes to main
  - `apply` - Runs `terragrunt apply -auto-approve` on push to main only (after validation passes)
- **`terraform/landing-page/terragrunt.hcl`** - Terragrunt config with S3 backend for remote state, DynamoDB locking, and auto-generated AWS provider
- **`terraform/landing-page/terraform.tf`** - Added empty `backend "s3" {}` block for Terragrunt to populate; removed inline provider (now generated)
- **`.gitignore`** - Added `provider-generated.tf` to avoid committing Terragrunt artifacts

## Key details

- Uses OIDC with `aws-actions/configure-aws-credentials` to assume `secrets.AWS_ROLE_ARN`
- `TF_VAR_hosted_zone_id` injected from `secrets.HOSTED_ZONE_ID`
- Triggers on changes to `landing-page/`, `terraform/landing-page/`, `assets/`, and the workflow itself
- Also supports `workflow_dispatch` for manual runs
- Terraform version constraint `>= 1.8, < 2.0` managed by Terragrunt
- State stored in `tf2-quickserver-terraform-state` bucket with DynamoDB locking

## Testing notes

- The S3 state bucket and DynamoDB table must exist before the first run
- The OIDC role must have permissions for S3, CloudFront, ACM, Route53, DynamoDB, and the state bucket