### PR TITLE
feat: add ozfortress bans enforcement plugin

### DIFF
--- a/variants/base/tf/cfg/server.cfg.template
+++ b/variants/base/tf/cfg/server.cfg.template
@@ -60,3 +60,4 @@ alias ozf-hl-koth "exec ozfortress_hl_koth"
 alias ozf-ud-ultiduo "exec ozfortress_ultiduo"
 alias ozf-ud "exec ozfortress_ultiduo"
 
+ozf_bans_enforce 0

--- a/variants/fat-standard-competitive-i386/Dockerfile
+++ b/variants/fat-standard-competitive-i386/Dockerfile
@@ -158,6 +158,16 @@ RUN curl -L "${OZFORTRESS_CONFIGS_URL}" -o "${OZFORTRESS_CONFIGS_FILE_NAME}" \
   && unzip -q "${OZFORTRESS_CONFIGS_FILE_NAME}" \
   && cp "server-configs-${OZFORTRESS_CONFIGS_VERSION}/cfg/"* "${PLUGIN_INSTALL_DIR}/cfg/"
 
+# ozfortress bans enforcement plugin
+ARG OZF_BANS_FILE_NAME=ozf_bans.zip
+ARG OZF_BANS_VERSION=2.0.3
+ARG OZF_BANS_URL=https://github.com/ozfortress/ozf-bans-enforcement/releases/download/v${OZF_BANS_VERSION}/${OZF_BANS_FILE_NAME}
+ARG OZF_BANS_CHECKSUM=9d3f9fda74c746d0f26863cc81096ca8f4c1cd7df18398f70d70e64b7c7146f8
+RUN curl -L "${OZF_BANS_URL}" -o "${OZF_BANS_FILE_NAME}" \
+  && echo "${OZF_BANS_CHECKSUM}  ${OZF_BANS_FILE_NAME}" | sha256sum -c \
+  && unzip -q "${OZF_BANS_FILE_NAME}" -d "${PLUGIN_INSTALL_DIR}/addons/sourcemod/" \
+  && rm "${OZF_BANS_FILE_NAME}"
+
 # SteamPawn - NativePawn compiler for Pawn scripting
 ARG STEAMPAWN_FILE_NAME=package.zip
 ARG STEAMPAWN_VERSION=1.2.0.2


### PR DESCRIPTION
Add the [ozfortress/ozf-bans-enforcement](https://github.com/ozfortress/ozf-bans-enforcement) SourceMod plugin v2.0.3 to the competitive i386 variant.

The plugin enforces ozfortress community bans on the server. It integrates with the existing ozfortress config aliases and `ozf_bans_enforce` setting already in `server.cfg.template`.

**Changes:**

- `variants/fat-standard-competitive-i386/Dockerfile` — Download and extract `ozf_bans.zip` into `addons/sourcemod/` with SHA256 verification. The zip ships files under `plugins/`, `scripting/`, and `translations/` which map directly into the SourceMod tree.
- `variants/base/tf/cfg/server.cfg.template` — Add `ozf_bans_enforce 0` to the ozfortress config section (needed by the plugin).

**Testing notes:** Build the `fat-standard-competitive-i386` image and verify the plugin loads. The config variable `ozf_bans_enforce 0` disables enforcement by default, matching the existing pattern of opt-in league enforcement.