### PR TITLE
Switch Enhanced Match Timer to ozfortress v1.5.2

### DIFF
--- a/variants/fat-standard-competitive-i386/Dockerfile
+++ b/variants/fat-standard-competitive-i386/Dockerfile
@@ -120,9 +120,13 @@ RUN curl -L "${STAC_PLUGIN_URL}" -o "${STAC_PLUGIN_FILE_NAME}" \
   && unzip -q -o "${STAC_PLUGIN_FILE_NAME}" -d "${PLUGIN_INSTALL_DIR}/addons/sourcemod/" \
   && rm "${STAC_PLUGIN_FILE_NAME}"
 
-# Enhanced Match Timer
-RUN curl -L "https://github.com/H20Gamez/Enhanced-Match-Timer/releases/download/Release/enhanced_match_timer.smx" \
-  -o "${PLUGIN_INSTALL_DIR}/addons/sourcemod/plugins/enhanced_match_timer.smx"
+# Enhanced Match Timer (ozfortress)
+ARG EMT_VERSION=v1.5.2
+ARG EMT_FILE_NAME=enhanced_match_timer.zip
+ARG EMT_URL=https://github.com/ozfortress/Enhanced-Match-Timer/releases/download/${EMT_VERSION}/${EMT_FILE_NAME}
+RUN curl -L "${EMT_URL}" -o "${EMT_FILE_NAME}" \
+  && unzip -q -j "${EMT_FILE_NAME}" "plugins/enhanced_match_timer.smx" -d "${PLUGIN_INSTALL_DIR}/addons/sourcemod/plugins/" \
+  && rm "${EMT_FILE_NAME}"
 
 # Updated Pause Plugin
 ARG UPDATED_PAUSE_FILE_NAME=updated-pause-plugin.zip


### PR DESCRIPTION
Replaces the H20Gamez/Enhanced-Match-Timer download with the authoritative ozfortress fork v1.5.2.

Both repos ship the same plugin (identical source code, same `.smx` filename, same cvars). The ozfortress version is actively maintained and version-pinned instead of tracking a floating `Release` tag.

**What changed**
- Download source: `H20Gamez/Enhanced-Match-Timer` -> `ozfortress/Enhanced-Match-Timer`
- Version pinned to v1.5.2 (was unversioned `Release` tag)
- Download is now a ZIP (extracted with unzip) instead of a direct .smx

**Why this is safe**
- Identical cvars: `mp_timelimit_improved`, `mp_timelimit_improved_arena`, `mp_timelimit_improved_threshold`, `sm_improvedtimers_chat`, etc.
- Same plugin filename: `enhanced_match_timer.smx` - all 14 configs that `sm plugins load/unload` it keep working
- No config file changes needed
- The ozfortress plugin auto-detects and disables the old `improved_match_timer.smx` if present