### PR TITLE
feat: add scheduled server creation

### DIFF
--- a/config/default.json
+++ b/config/default.json
@@ -5,56 +5,64 @@
             "srcdsHostname": "TF2-QuickServer | São Paulo",
             "tvHostname": "TF2-QuickServer TV | São Paulo",
             "cloudProvider": "oracle",
-            "homeRegion": "us-chicago-1"
+            "homeRegion": "us-chicago-1",
+            "scheduledCreationLeadMinutes": 5
         },
         "sa-santiago-1": {
             "displayName": "Santiago",
             "srcdsHostname": "TF2-QuickServer | Santiago",
             "tvHostname": "TF2-QuickServer TV | Santiago",
             "cloudProvider": "oracle",
-            "homeRegion": "sa-santiago-1"
+            "homeRegion": "sa-santiago-1",
+            "scheduledCreationLeadMinutes": 5
         },
         "sa-bogota-1": {
             "displayName": "Bogotá",
             "srcdsHostname": "TF2-QuickServer | Bogotá",
             "tvHostname": "TF2-QuickServer TV | Bogotá",
             "cloudProvider": "oracle",
-            "homeRegion": "us-chicago-1"
+            "homeRegion": "us-chicago-1",
+            "scheduledCreationLeadMinutes": 5
         },
         "us-chicago-1": {
             "displayName": "Chicago",
             "srcdsHostname": "TF2-QuickServer | Chicago",
             "tvHostname": "TF2-QuickServer TV | Chicago",
             "cloudProvider": "oracle",
-            "homeRegion": "us-chicago-1"
+            "homeRegion": "us-chicago-1",
+            "scheduledCreationLeadMinutes": 5
         },
         "eu-frankfurt-1": {
             "displayName": "Frankfurt",
             "srcdsHostname": "TF2-QuickServer | Frankfurt",
             "tvHostname": "TF2-QuickServer TV | Frankfurt",
             "cloudProvider": "oracle",
-            "homeRegion": "sa-santiago-1"
+            "homeRegion": "sa-santiago-1",
+            "scheduledCreationLeadMinutes": 5
         },
         "ap-sydney-1": {
             "displayName": "Sydney",
             "srcdsHostname": "TF2-QuickServer | Sydney",
             "tvHostname": "TF2-QuickServer TV | Sydney",
             "cloudProvider": "oracle",
-            "homeRegion": "sa-santiago-1"
+            "homeRegion": "sa-santiago-1",
+            "scheduledCreationLeadMinutes": 5
         },
         "us-east-1-bue-1": {
             "displayName": "Buenos Aires (Experimental)",
             "srcdsHostname": "TF2-QuickServer | Buenos Aires",
             "tvHostname": "TF2-QuickServer TV | Buenos Aires",
             "cloudProvider": "aws",
-            "homeRegion": "us-east-1"
+            "homeRegion": "us-east-1",
+            "scheduledCreationLeadMinutes": 12
         },
         "us-east-1-lim-1": {
             "displayName": "Lima (Experimental)",
             "srcdsHostname": "TF2-QuickServer | Lima",
             "tvHostname": "TF2-QuickServer TV | Lima",
             "cloudProvider": "aws",
-            "homeRegion": "us-east-1"
+            "homeRegion": "us-east-1",
+            "scheduledCreationLeadMinutes": 12
         }
     },
     "variants": {

--- a/migrations/20260801120000_scheduled_servers.ts
+++ b/migrations/20260801120000_scheduled_servers.ts
@@ -1,0 +1,28 @@
+import type { Knex } from "knex";
+
+
+export async function up(knex: Knex): Promise<void> {
+    await knex.schema.createTable("scheduled_servers", (table) => {
+        table.string("id").primary();
+        table.string("userId").notNullable();
+        table.string("guildId").nullable();
+        table.string("region").notNullable();
+        table.string("variant").notNullable();
+        table.timestamp("scheduledAt").notNullable();
+        table.timestamp("triggerAt").notNullable();
+        table.string("status").notNullable().defaultTo("scheduled");
+        table.check("status IN ('scheduled','creating','created','failed','cancelled')");
+        table.string("serverId").nullable();
+        table.string("timezone").notNullable();
+        table.timestamp("createdAt").defaultTo(knex.fn.now()).notNullable();
+        table.timestamp("updatedAt").defaultTo(knex.fn.now()).notNullable();
+        table.index(["userId"]);
+        table.index(["status"]);
+        table.index(["status", "triggerAt"]);
+    });
+}
+
+
+export async function down(knex: Knex): Promise<void> {
+    await knex.schema.dropTableIfExists("scheduled_servers");
+}

--- a/packages/core/index.ts
+++ b/packages/core/index.ts
@@ -17,6 +17,7 @@ export * from './src/repository/UserRepository';
 export * from './src/repository/UserBanRepository';
 export * from './src/repository/ServerStatusMetricsRepository';
 export * from './src/repository/PlayerConnectionHistoryRepository';
+export * from './src/repository/ScheduledServerRepository';
 
 // Services
 export * from './src/services/BackgroundTaskQueue';
@@ -37,12 +38,17 @@ export * from './src/services/TF2ServerReadinessService';
 // Use cases
 export * from './src/usecase/CreateServerForClient';
 export * from './src/usecase/CreateServerForUser';
+export * from './src/usecase/CreateScheduledServer';
+export * from './src/usecase/CancelScheduledServer';
 export * from './src/usecase/DeleteServer';
 export * from './src/usecase/DeleteServerForUser';
+export * from './src/usecase/ExecuteScheduledServerCreation';
+export * from './src/usecase/ExecuteScheduledServers';
 export * from './src/usecase/GenerateMonthlyUsageReport';
 export * from './src/usecase/GetServerStatus';
 export * from './src/usecase/GetGuildServers';
 export * from './src/usecase/GetUserServers';
+export * from './src/usecase/GetUserSchedules';
 export * from './src/usecase/SetUserData';
 export * from './src/usecase/TerminateEmptyServers';
 export * from './src/usecase/TerminateLongRunningServers';
@@ -51,3 +57,5 @@ export * from './src/usecase/TerminatePendingServers';
 // Utils
 export * from './src/utils/ConfigManager';
 export * from './src/utils/interpolateString';
+export * from './src/utils/scheduleTime';
+export * from './src/utils/failSafeDirectMessage';

--- a/packages/core/src/domain/Region.ts
+++ b/packages/core/src/domain/Region.ts
@@ -18,6 +18,11 @@ export type RegionConfig = {
     tvHostname: string;
     cloudProvider: CloudProvider;
     homeRegion?: string;
+    /**
+     * How many minutes before the user's scheduled ready time the server should start being created.
+     * @default 5
+     */
+    scheduledCreationLeadMinutes?: number;
 }
 
 export function isValidRegion(region: string): region is Region {
@@ -58,4 +63,15 @@ export function getRegions(): Region[] {
 export function getCloudProvider(region: Region): CloudProvider {
     const regionConfig = getRegionConfig(region);
     return regionConfig.cloudProvider;
+}
+
+/**
+ * Gets the lead time in minutes before a scheduled server should start being created.
+ *
+ * @param region - The region to check
+ * @returns The lead time in minutes (defaults to 5)
+ */
+export function getScheduledCreationLeadMinutes(region: Region): number {
+    const regionConfig = getRegionConfig(region);
+    return regionConfig.scheduledCreationLeadMinutes ?? 5;
 }

--- a/packages/core/src/domain/ScheduledServer.ts
+++ b/packages/core/src/domain/ScheduledServer.ts
@@ -1,0 +1,19 @@
+import { Region } from "./Region";
+import { Variant } from "./Variant";
+
+export type ScheduledServerStatus = "scheduled" | "creating" | "created" | "failed" | "cancelled";
+
+export interface ScheduledServer {
+    id: string;
+    userId: string;          // Discord user id (creator)
+    guildId?: string | null; // guild the /schedule command ran in
+    region: Region;
+    variant: Variant;
+    scheduledAt: Date;       // user's expected ready time, UTC
+    triggerAt: Date;         // scheduledAt - leadMinutes, UTC (computed at creation)
+    status: ScheduledServerStatus;
+    serverId?: string | null;
+    timezone: string;        // IANA tz chosen by user
+    createdAt: Date;
+    updatedAt: Date;
+}

--- a/packages/core/src/domain/index.ts
+++ b/packages/core/src/domain/index.ts
@@ -1,4 +1,5 @@
 export * from "./DeployedServer"
+export * from "./ScheduledServer";
 export * from "./Region";
 export * from "./Variant";
 export * from "./DiscordConfig";

--- a/packages/core/src/repository/ScheduledServerRepository.ts
+++ b/packages/core/src/repository/ScheduledServerRepository.ts
@@ -1,0 +1,12 @@
+import { ScheduledServer, ScheduledServerStatus } from "../domain";
+
+export interface ScheduledServerRepository {
+    create(schedule: ScheduledServer): Promise<void>;
+    findById(id: string): Promise<ScheduledServer | null>;
+    findActiveByUserId(userId: string): Promise<ScheduledServer[]>; // status IN ('scheduled','creating') ordered by scheduledAt ASC
+    findDue(now: Date): Promise<ScheduledServer[]>; // status='scheduled' AND triggerAt <= now
+    findStuckCreating(before: Date): Promise<ScheduledServer[]>; // status='creating' AND updatedAt <= before
+    claimForProcessing(id: string, now: Date): Promise<boolean>; // atomic 'scheduled'->'creating'; false if already claimed
+    markStatus(id: string, status: ScheduledServerStatus, serverId?: string, now?: Date): Promise<void>;
+    cancel(id: string, now: Date): Promise<boolean>; // 'scheduled'->'cancelled'; false if no longer cancellable
+}

--- a/packages/core/src/usecase/CancelScheduledServer.test.ts
+++ b/packages/core/src/usecase/CancelScheduledServer.test.ts
@@ -1,0 +1,85 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import { mock } from "vitest-mock-extended";
+import { Region } from "../domain/Region";
+import { ScheduledServer } from "../domain/ScheduledServer";
+import { ScheduledServerRepository } from "../repository/ScheduledServerRepository";
+import { EventLogger } from "../services/EventLogger";
+import { UserError } from "../errors/UserError";
+import { CancelScheduledServer } from "./CancelScheduledServer";
+
+function createSchedule(overrides: Partial<ScheduledServer> = {}): ScheduledServer {
+    return {
+        id: "schedule-1",
+        userId: "user-1",
+        guildId: null,
+        region: "sa-saopaulo-1" as Region,
+        variant: "standard-competitive" as const,
+        scheduledAt: new Date("2026-08-01T21:30:00Z"),
+        triggerAt: new Date("2026-08-01T21:25:00Z"),
+        status: "scheduled",
+        serverId: null,
+        timezone: "UTC",
+        createdAt: new Date("2026-08-01T10:00:00Z"),
+        updatedAt: new Date("2026-08-01T10:00:00Z"),
+        ...overrides,
+    };
+}
+
+describe("CancelScheduledServer", () => {
+    let scheduledServerRepository: ReturnType<typeof mock<ScheduledServerRepository>>;
+    let eventLogger: ReturnType<typeof mock<EventLogger>>;
+    let sut: CancelScheduledServer;
+
+    beforeEach(() => {
+        scheduledServerRepository = mock<ScheduledServerRepository>();
+        eventLogger = mock<EventLogger>();
+        sut = new CancelScheduledServer({ scheduledServerRepository, eventLogger });
+    });
+
+    it("should cancel a scheduled server and return the updated row", async () => {
+        // Given
+        const schedule = createSchedule();
+        scheduledServerRepository.findActiveByUserId.mockResolvedValue([schedule]);
+        scheduledServerRepository.cancel.mockResolvedValue(true);
+
+        // When
+        const result = await sut.execute({ userId: "user-1" });
+
+        // Then
+        expect(scheduledServerRepository.cancel).toHaveBeenCalledWith("schedule-1", expect.any(Date));
+        expect(eventLogger.log).toHaveBeenCalled();
+        expect(result.status).toBe("cancelled");
+    });
+
+    it("should throw UserError if there is no active schedule", async () => {
+        // Given
+        scheduledServerRepository.findActiveByUserId.mockResolvedValue([]);
+
+        // When/Then
+        await expect(sut.execute({ userId: "user-1" })).rejects.toThrow(UserError);
+        await expect(sut.execute({ userId: "user-1" })).rejects.toThrow("You don't have an active scheduled server.");
+        expect(scheduledServerRepository.cancel).not.toHaveBeenCalled();
+    });
+
+    it("should throw UserError if the schedule is already being created", async () => {
+        // Given
+        const schedule = createSchedule({ status: "creating" });
+        scheduledServerRepository.findActiveByUserId.mockResolvedValue([schedule]);
+
+        // When/Then
+        await expect(sut.execute({ userId: "user-1" })).rejects.toThrow(UserError);
+        await expect(sut.execute({ userId: "user-1" })).rejects.toThrow("too late");
+        expect(scheduledServerRepository.cancel).not.toHaveBeenCalled();
+    });
+
+    it("should throw UserError if cancel races and returns false", async () => {
+        // Given
+        const schedule = createSchedule();
+        scheduledServerRepository.findActiveByUserId.mockResolvedValue([schedule]);
+        scheduledServerRepository.cancel.mockResolvedValue(false);
+
+        // When/Then
+        await expect(sut.execute({ userId: "user-1" })).rejects.toThrow(UserError);
+        expect(scheduledServerRepository.cancel).toHaveBeenCalledWith("schedule-1", expect.any(Date));
+    });
+});

--- a/packages/core/src/usecase/CancelScheduledServer.ts
+++ b/packages/core/src/usecase/CancelScheduledServer.ts
@@ -1,0 +1,45 @@
+import { ScheduledServer } from "../domain";
+import { UserError } from "../errors/UserError";
+import { ScheduledServerRepository } from "../repository/ScheduledServerRepository";
+import { EventLogger } from "../services/EventLogger";
+
+export class CancelScheduledServer {
+    constructor(private readonly dependencies: {
+        scheduledServerRepository: ScheduledServerRepository,
+        eventLogger: EventLogger,
+    }) { }
+
+    async execute(args: { userId: string }): Promise<ScheduledServer> {
+        const { scheduledServerRepository, eventLogger } = this.dependencies;
+        const { userId } = args;
+
+        const active = await scheduledServerRepository.findActiveByUserId(userId);
+        if (active.length === 0) {
+            throw new UserError('You don\'t have an active scheduled server.');
+        }
+
+        const schedule = active[0];
+        if (schedule.status === 'creating') {
+            throw new UserError('It\'s too late to cancel — your server creation has already started.');
+        }
+
+        const now = new Date();
+        const cancelled = await scheduledServerRepository.cancel(schedule.id, now);
+        if (!cancelled) {
+            throw new UserError('Your schedule could not be cancelled (it may have just started). Please check /show-schedules.');
+        }
+
+        const cancelledSchedule: ScheduledServer = {
+            ...schedule,
+            status: "cancelled",
+            updatedAt: now,
+        };
+
+        await eventLogger.log({
+            actorId: userId,
+            eventMessage: `User cancelled their scheduled server for ${schedule.scheduledAt.toISOString()}`
+        });
+
+        return cancelledSchedule;
+    }
+}

--- a/packages/core/src/usecase/CreateScheduledServer.test.ts
+++ b/packages/core/src/usecase/CreateScheduledServer.test.ts
@@ -1,0 +1,143 @@
+import { Client as DiscordClient, User, UserManager } from "discord.js";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { mock } from "vitest-mock-extended";
+import { when } from "vitest-when";
+import { Region } from "../domain/Region";
+import { ScheduledServerRepository } from "../repository/ScheduledServerRepository";
+import { EventLogger } from "../services/EventLogger";
+import { IdGenerator } from "../services/IdGenerator";
+import { UserError } from "../errors/UserError";
+import { CreateScheduledServer } from "./CreateScheduledServer";
+import { getScheduledCreationLeadMinutes } from "../domain/Region";
+
+describe("CreateScheduledServer", () => {
+    let scheduledServerRepository: ReturnType<typeof mock<ScheduledServerRepository>>;
+    let idGenerator: ReturnType<typeof mock<IdGenerator>>;
+    let discordBot: ReturnType<typeof mock<DiscordClient>>;
+    let users: ReturnType<typeof mock<UserManager>>;
+    let eventLogger: ReturnType<typeof mock<EventLogger>>;
+    let user: ReturnType<typeof mock<User>>;
+    let sut: CreateScheduledServer;
+
+    beforeEach(() => {
+        scheduledServerRepository = mock<ScheduledServerRepository>();
+        idGenerator = mock<IdGenerator>();
+        users = mock<UserManager>();
+        discordBot = mock<DiscordClient>({ users });
+        eventLogger = mock<EventLogger>();
+        user = mock<User>();
+
+        idGenerator.generate.mockReturnValue("schedule-id-1");
+        users.fetch.mockResolvedValue(user);
+        user.send.mockResolvedValue(undefined as any);
+        scheduledServerRepository.findActiveByUserId.mockResolvedValue([]);
+
+        sut = new CreateScheduledServer({
+            scheduledServerRepository,
+            idGenerator,
+            discordBot,
+            eventLogger,
+        });
+    });
+
+    const baseArgs = {
+        userId: "user-1",
+        region: "sa-saopaulo-1" as Region,
+        variantName: "standard-competitive" as const,
+        time: "21:30",
+        timezone: "UTC",
+    };
+
+    it("should compute scheduledAt, send the confirmation DM before persisting, and persist the row", async () => {
+        // Given a fixed current time
+        vi.useFakeTimers();
+        vi.setSystemTime(new Date("2026-08-01T10:00:00Z"));
+
+        // When
+        const result = await sut.execute(baseArgs);
+
+        // Then the confirmation DM was sent before persisting
+        expect(user.send).toHaveBeenCalledWith(expect.stringContaining("Server Scheduled"));
+        expect(scheduledServerRepository.create).toHaveBeenCalledTimes(1);
+
+        // And the persisted row uses the computed times and generated id
+        const created = scheduledServerRepository.create.mock.calls[0][0];
+        expect(created.id).toBe("schedule-id-1");
+        expect(created.scheduledAt.toISOString()).toBe("2026-08-01T21:30:00.000Z");
+        const leadMs = getScheduledCreationLeadMinutes(Region.SA_SAOPAULO_1) * 60_000;
+        expect(created.triggerAt.toISOString()).toBe(
+            new Date(new Date("2026-08-01T21:30:00.000Z").getTime() - leadMs).toISOString()
+        );
+        expect(created.status).toBe("scheduled");
+        expect(created.userId).toBe("user-1");
+        expect(created.variant).toBe("standard-competitive");
+        expect(created.timezone).toBe("UTC");
+        expect(result).toEqual(created);
+
+        vi.useRealTimers();
+    });
+
+    it("should throw UserError and not persist if the user already has an active schedule", async () => {
+        // Given an existing active schedule
+        scheduledServerRepository.findActiveByUserId.mockResolvedValue([{
+            id: "existing-1",
+            userId: "user-1",
+            guildId: null,
+            region: "sa-saopaulo-1" as Region,
+            variant: "standard-competitive" as const,
+            scheduledAt: new Date("2026-08-02T21:30:00Z"),
+            triggerAt: new Date("2026-08-02T21:25:00Z"),
+            status: "scheduled" as const,
+            serverId: null,
+            timezone: "UTC",
+            createdAt: new Date(),
+            updatedAt: new Date(),
+        }]);
+
+        // When/Then
+        await expect(sut.execute(baseArgs)).rejects.toThrow(UserError);
+        await expect(sut.execute(baseArgs)).rejects.toThrow("You can only schedule one server at a time");
+        expect(scheduledServerRepository.create).not.toHaveBeenCalled();
+        expect(user.send).not.toHaveBeenCalled();
+    });
+
+    it("should throw UserError and not persist if the confirmation DM cannot be sent", async () => {
+        // Given the DM send fails
+        user.send.mockRejectedValue(new Error("Cannot send messages to this user"));
+
+        // When/Then
+        await expect(sut.execute(baseArgs)).rejects.toThrow(UserError);
+        expect(scheduledServerRepository.create).not.toHaveBeenCalled();
+    });
+
+    it("should throw UserError and not persist if the user cannot be fetched", async () => {
+        // Given the user fetch fails
+        users.fetch.mockRejectedValue(new Error("Unknown User"));
+
+        // When/Then
+        await expect(sut.execute(baseArgs)).rejects.toThrow(UserError);
+        expect(scheduledServerRepository.create).not.toHaveBeenCalled();
+    });
+
+    it("should throw UserError for an invalid time", async () => {
+        // When/Then
+        await expect(sut.execute({ ...baseArgs, time: "25:99" })).rejects.toThrow(UserError);
+        expect(scheduledServerRepository.create).not.toHaveBeenCalled();
+        expect(user.send).not.toHaveBeenCalled();
+    });
+
+    it("should roll past times forward to tomorrow's date in the persisted row", async () => {
+        // Given a fixed current time after 21:30 UTC
+        vi.useFakeTimers();
+        vi.setSystemTime(new Date("2026-08-01T22:00:00Z"));
+
+        // When
+        await sut.execute(baseArgs);
+
+        // Then the persisted row's scheduledAt is tomorrow
+        const created = scheduledServerRepository.create.mock.calls[0][0];
+        expect(created.scheduledAt.toISOString()).toBe("2026-08-02T21:30:00.000Z");
+
+        vi.useRealTimers();
+    });
+});

--- a/packages/core/src/usecase/CreateScheduledServer.ts
+++ b/packages/core/src/usecase/CreateScheduledServer.ts
@@ -1,0 +1,81 @@
+import { Client } from "discord.js";
+import { getRegionDisplayName, getVariantConfig, Region, ScheduledServer, Variant } from "../domain";
+import { UserError } from "../errors/UserError";
+import { ScheduledServerRepository } from "../repository/ScheduledServerRepository";
+import { EventLogger } from "../services/EventLogger";
+import { IdGenerator } from "../services/IdGenerator";
+import { getScheduledCreationLeadMinutes } from "../domain/Region";
+import { computeNextOccurrence, formatDateTimeInTimeZone, formatDurationUntil } from "../utils/scheduleTime";
+
+export class CreateScheduledServer {
+
+    constructor(private readonly dependencies: {
+        scheduledServerRepository: ScheduledServerRepository,
+        idGenerator: IdGenerator,
+        discordBot: Client,
+        eventLogger: EventLogger,
+    }) { }
+
+    public async execute(args: {
+        userId: string,
+        guildId?: string,
+        region: Region,
+        variantName: Variant,
+        time: string,
+        timezone: string,
+    }): Promise<ScheduledServer> {
+        const { scheduledServerRepository, idGenerator, discordBot, eventLogger } = this.dependencies;
+
+        const existing = await scheduledServerRepository.findActiveByUserId(args.userId);
+        if (existing.length > 0) {
+            const active = existing[0];
+            const variantDisplayName = getVariantConfig(active.variant).displayName ?? active.variant;
+            throw new UserError(`You can only schedule one server at a time. You already have a schedule for ${variantDisplayName} on ${formatDateTimeInTimeZone(active.scheduledAt, active.timezone)}.`);
+        }
+
+        const now = new Date();
+        const scheduledAt = computeNextOccurrence({ time: args.time, timezone: args.timezone, now });
+        const triggerAt = new Date(scheduledAt.getTime() - getScheduledCreationLeadMinutes(args.region) * 60_000);
+
+        const regionDisplayName = getRegionDisplayName(args.region);
+        const variantDisplayName = getVariantConfig(args.variantName).displayName ?? args.variantName;
+        const confirmationMessage =
+            `🗓️ **Server Scheduled!**\n` +
+            `Region: **${regionDisplayName}** · Variant: **${variantDisplayName}**\n` +
+            `⏰ Ready at: **${formatDateTimeInTimeZone(scheduledAt, args.timezone)}** (${args.timezone})\n` +
+            `🕐 (${formatDateTimeInTimeZone(scheduledAt, 'UTC')} UTC) — ${formatDurationUntil(scheduledAt, now)} from now\n` +
+            `I'll DM you here when your server starts being created, and again with the connection info once it's ready.`;
+
+        // DM validation: the schedule must NOT be persisted if the DM cannot be sent.
+        try {
+            const user = await discordBot.users.fetch(args.userId);
+            await user.send(confirmationMessage);
+        } catch (error) {
+            throw new UserError('I need to be able to DM you to deliver your server connection info. Please enable DMs from this bot (User Settings → Privacy & Safety → allow messages from server members) and try again.');
+        }
+
+        const schedule: ScheduledServer = {
+            id: idGenerator.generate(),
+            userId: args.userId,
+            guildId: args.guildId ?? null,
+            region: args.region,
+            variant: args.variantName,
+            scheduledAt,
+            triggerAt,
+            status: "scheduled",
+            serverId: null,
+            timezone: args.timezone,
+            createdAt: now,
+            updatedAt: now,
+        };
+
+        await scheduledServerRepository.create(schedule);
+
+        await eventLogger.log({
+            actorId: args.userId,
+            eventMessage: `User scheduled a server in region ${args.region} with variant ${args.variantName} for ${scheduledAt.toISOString()}`
+        });
+
+        return schedule;
+    }
+}

--- a/packages/core/src/usecase/ExecuteScheduledServerCreation.test.ts
+++ b/packages/core/src/usecase/ExecuteScheduledServerCreation.test.ts
@@ -1,0 +1,203 @@
+import { Client as DiscordClient, User, UserManager } from "discord.js";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { mock } from "vitest-mock-extended";
+import { Region } from "../domain/Region";
+import { Server } from "../domain/DeployedServer";
+import { ScheduledServer } from "../domain/ScheduledServer";
+import { ScheduledServerRepository } from "../repository/ScheduledServerRepository";
+import { EventLogger } from "../services/EventLogger";
+import { UserError } from "../errors/UserError";
+import { CreateServerForUser } from "./CreateServerForUser";
+import { ExecuteScheduledServerCreation } from "./ExecuteScheduledServerCreation";
+
+function createSchedule(overrides: Partial<ScheduledServer> = {}): ScheduledServer {
+    return {
+        id: "schedule-1",
+        userId: "user-1",
+        guildId: null,
+        region: "sa-saopaulo-1" as Region,
+        variant: "standard-competitive" as const,
+        scheduledAt: new Date("2026-08-01T21:30:00Z"),
+        triggerAt: new Date("2026-08-01T21:25:00Z"),
+        status: "scheduled",
+        serverId: null,
+        timezone: "UTC",
+        createdAt: new Date("2026-08-01T10:00:00Z"),
+        updatedAt: new Date("2026-08-01T10:00:00Z"),
+        ...overrides,
+    };
+}
+
+function createServer(overrides: Partial<Server> = {}): Server {
+    return {
+        serverId: "server-1",
+        region: "sa-saopaulo-1" as any,
+        variant: "standard-competitive" as any,
+        hostIp: "127.0.0.1",
+        hostPort: 27015,
+        tvIp: "127.0.0.1",
+        tvPort: 27020,
+        rconPassword: "rconpass",
+        rconAddress: "127.0.0.1",
+        createdAt: new Date(),
+        createdBy: "user-1",
+        status: "ready",
+        ...overrides,
+    };
+}
+
+describe("ExecuteScheduledServerCreation", () => {
+    let scheduledServerRepository: ReturnType<typeof mock<ScheduledServerRepository>>;
+    let createServerForUser: ReturnType<typeof mock<CreateServerForUser>>;
+    let discordBot: ReturnType<typeof mock<DiscordClient>>;
+    let users: ReturnType<typeof mock<UserManager>>;
+    let eventLogger: ReturnType<typeof mock<EventLogger>>;
+    let serverMessageFormatter: ReturnType<typeof vi.fn>;
+    let user: ReturnType<typeof mock<User>>;
+    let sut: ExecuteScheduledServerCreation;
+
+    beforeEach(() => {
+        scheduledServerRepository = mock<ScheduledServerRepository>();
+        createServerForUser = mock<CreateServerForUser>();
+        users = mock<UserManager>();
+        discordBot = mock<DiscordClient>({ users });
+        eventLogger = mock<EventLogger>();
+        serverMessageFormatter = vi.fn().mockReturnValue("connect 127.0.0.1:27015; password rconpass");
+        user = mock<User>();
+
+        users.fetch.mockResolvedValue(user);
+        user.send.mockResolvedValue(undefined as any);
+        scheduledServerRepository.findById.mockResolvedValue(null);
+
+        sut = new ExecuteScheduledServerCreation({
+            scheduledServerRepository,
+            createServerForUser,
+            discordBot,
+            eventLogger,
+            serverMessageFormatter,
+        });
+    });
+
+    it("should send the being-created DM, create the server, mark it created, and DM the connection info", async () => {
+        // Given
+        const schedule = createSchedule();
+        scheduledServerRepository.findById.mockResolvedValue(schedule);
+        const server = createServer();
+        let capturedStatusUpdater: ((message: string) => Promise<void>) | undefined;
+        createServerForUser.execute.mockImplementation(async (args) => {
+            capturedStatusUpdater = args.statusUpdater;
+            return server;
+        });
+
+        // When
+        await sut.execute({ scheduleId: "schedule-1" });
+
+        // Then
+        expect(scheduledServerRepository.findById).toHaveBeenCalledWith("schedule-1");
+        expect(user.send).toHaveBeenCalledTimes(2);
+        expect(user.send).toHaveBeenNthCalledWith(1, expect.stringContaining("being created"));
+        expect(user.send).toHaveBeenNthCalledWith(2, "connect 127.0.0.1:27015; password rconpass");
+        expect(createServerForUser.execute).toHaveBeenCalledWith({
+            region: schedule.region,
+            variantName: schedule.variant,
+            creatorId: schedule.userId,
+            guildId: undefined,
+            statusUpdater: expect.any(Function),
+        });
+        expect(scheduledServerRepository.markStatus).toHaveBeenCalledWith("schedule-1", "created", "server-1", expect.any(Date));
+        expect(serverMessageFormatter).toHaveBeenCalledWith(server);
+        expect(eventLogger.log).toHaveBeenCalledWith(expect.objectContaining({ eventMessage: expect.stringContaining("created successfully") }));
+
+        // The statusUpdater passed to createServerForUser must not send any DMs
+        await capturedStatusUpdater!("🛡️ [1/5] Creating SHIELD Firewall...");
+        expect(user.send).toHaveBeenCalledTimes(2);
+    });
+
+    it("should pass the schedule guildId to createServerForUser", async () => {
+        // Given
+        const schedule = createSchedule({ guildId: "guild-1" });
+        scheduledServerRepository.findById.mockResolvedValue(schedule);
+        createServerForUser.execute.mockResolvedValue(createServer());
+
+        // When
+        await sut.execute({ scheduleId: "schedule-1" });
+
+        // Then
+        expect(createServerForUser.execute).toHaveBeenCalledWith(expect.objectContaining({ guildId: "guild-1" }));
+    });
+
+    it("should return without creating or DMing when the schedule is not found", async () => {
+        // Given
+        scheduledServerRepository.findById.mockResolvedValue(null);
+
+        // When
+        await sut.execute({ scheduleId: "missing-schedule" });
+
+        // Then
+        expect(createServerForUser.execute).not.toHaveBeenCalled();
+        expect(scheduledServerRepository.markStatus).not.toHaveBeenCalled();
+        expect(user.send).not.toHaveBeenCalled();
+        expect(eventLogger.log).toHaveBeenCalledWith(expect.objectContaining({ eventMessage: expect.stringContaining("missing-schedule") }));
+    });
+
+    it("should mark the schedule failed and DM the reason when creation throws a UserError", async () => {
+        // Given
+        const schedule = createSchedule();
+        scheduledServerRepository.findById.mockResolvedValue(schedule);
+        createServerForUser.execute.mockRejectedValue(new UserError("User does not have a SteamID set."));
+
+        // When
+        await sut.execute({ scheduleId: "schedule-1" });
+
+        // Then
+        expect(scheduledServerRepository.markStatus).toHaveBeenCalledWith("schedule-1", "failed", undefined, expect.any(Date));
+        expect(user.send).toHaveBeenCalledTimes(2);
+        expect(user.send).toHaveBeenNthCalledWith(1, expect.stringContaining("being created"));
+        expect(user.send).toHaveBeenNthCalledWith(2, "User does not have a SteamID set.");
+        expect(eventLogger.log).toHaveBeenCalledWith(expect.objectContaining({ eventMessage: expect.stringContaining("creation failed") }));
+    });
+
+    it("should mark the schedule failed and DM a generic reason on unexpected errors", async () => {
+        // Given
+        const schedule = createSchedule();
+        scheduledServerRepository.findById.mockResolvedValue(schedule);
+        createServerForUser.execute.mockRejectedValue(new Error("boom"));
+
+        // When
+        await sut.execute({ scheduleId: "schedule-1" });
+
+        // Then
+        expect(scheduledServerRepository.markStatus).toHaveBeenCalledWith("schedule-1", "failed", undefined, expect.any(Date));
+        expect(user.send).toHaveBeenCalledTimes(2);
+        expect(user.send).toHaveBeenNthCalledWith(1, expect.stringContaining("being created"));
+        expect(user.send).toHaveBeenNthCalledWith(2, "Your scheduled server could not be created due to an unexpected error.");
+        expect(eventLogger.log).toHaveBeenCalledWith(expect.objectContaining({ eventMessage: expect.stringContaining("creation failed") }));
+    });
+
+    it("should still mark the schedule created and resolve when DMs fail", async () => {
+        // Given
+        const schedule = createSchedule();
+        scheduledServerRepository.findById.mockResolvedValue(schedule);
+        createServerForUser.execute.mockResolvedValue(createServer());
+        users.fetch.mockRejectedValue(new Error("Cannot send messages to this user"));
+
+        // When
+        await expect(sut.execute({ scheduleId: "schedule-1" })).resolves.toBeUndefined();
+
+        // Then
+        expect(createServerForUser.execute).toHaveBeenCalled();
+        expect(scheduledServerRepository.markStatus).toHaveBeenCalledWith("schedule-1", "created", "server-1", expect.any(Date));
+    });
+
+    it("should propagate a markStatus failure instead of swallowing it", async () => {
+        // Given
+        const schedule = createSchedule();
+        scheduledServerRepository.findById.mockResolvedValue(schedule);
+        createServerForUser.execute.mockRejectedValue(new Error("boom"));
+        scheduledServerRepository.markStatus.mockRejectedValue(new Error("db down"));
+
+        // When/Then — the rejection from markStatus inside the catch block surfaces to the
+        // caller (the background task queue) rather than becoming an unhandled rejection
+        await expect(sut.execute({ scheduleId: "schedule-1" })).rejects.toThrow("db down");
+    });
+});

--- a/packages/core/src/usecase/ExecuteScheduledServerCreation.ts
+++ b/packages/core/src/usecase/ExecuteScheduledServerCreation.ts
@@ -1,0 +1,61 @@
+import { Client } from "discord.js";
+import { Server } from "../domain";
+import { UserError } from "../errors/UserError";
+import { ScheduledServerRepository } from "../repository/ScheduledServerRepository";
+import { EventLogger } from "../services/EventLogger";
+import { CreateServerForUser } from "./CreateServerForUser";
+import { failSafeDirectMessage } from "../utils/failSafeDirectMessage";
+
+export class ExecuteScheduledServerCreation {
+
+    constructor(private readonly dependencies: {
+        scheduledServerRepository: ScheduledServerRepository,
+        createServerForUser: CreateServerForUser,
+        discordBot: Client,
+        eventLogger: EventLogger,
+        serverMessageFormatter: (server: Server) => string,
+    }) { }
+
+    public async execute({ scheduleId }: { scheduleId: string }): Promise<void> {
+        const { scheduledServerRepository, createServerForUser, discordBot, eventLogger, serverMessageFormatter } = this.dependencies;
+
+        const schedule = await scheduledServerRepository.findById(scheduleId);
+        if (!schedule) {
+            await eventLogger.log({
+                actorId: 'system',
+                eventMessage: `Scheduled server ${scheduleId} not found when processing its creation — it was likely already processed or deleted.`
+            });
+            return;
+        }
+
+        await failSafeDirectMessage(discordBot, schedule.userId, '⏳ Your scheduled server is being created…');
+
+        try {
+            const server = await createServerForUser.execute({
+                region: schedule.region,
+                variantName: schedule.variant,
+                creatorId: schedule.userId,
+                guildId: schedule.guildId ?? undefined,
+                statusUpdater: async () => {},
+            });
+            await scheduledServerRepository.markStatus(schedule.id, "created", server.serverId, new Date());
+            // Connection info DM — DM-ability was verified at scheduling time, so a
+            // failure here does not abort or revert the creation (edge case 7)
+            await failSafeDirectMessage(discordBot, schedule.userId, serverMessageFormatter(server));
+            await eventLogger.log({
+                actorId: schedule.userId,
+                eventMessage: `Scheduled server ${schedule.id} created successfully.`
+            });
+        } catch (error) {
+            await scheduledServerRepository.markStatus(schedule.id, "failed", undefined, new Date());
+            const reason = error instanceof UserError
+                ? error.message
+                : 'Your scheduled server could not be created due to an unexpected error.';
+            await failSafeDirectMessage(discordBot, schedule.userId, reason);
+            await eventLogger.log({
+                actorId: schedule.userId,
+                eventMessage: `Scheduled server ${schedule.id} creation failed: ${error instanceof Error ? error.message : String(error)}`
+            });
+        }
+    }
+}

--- a/packages/core/src/usecase/ExecuteScheduledServers.test.ts
+++ b/packages/core/src/usecase/ExecuteScheduledServers.test.ts
@@ -1,0 +1,158 @@
+import { Client as DiscordClient, User, UserManager } from "discord.js";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { mock } from "vitest-mock-extended";
+import { Region } from "../domain/Region";
+import { ScheduledServer } from "../domain/ScheduledServer";
+import { ScheduledServerRepository } from "../repository/ScheduledServerRepository";
+import { EventLogger } from "../services/EventLogger";
+import { BackgroundTaskQueue } from "../services/BackgroundTaskQueue";
+import { ExecuteScheduledServers } from "./ExecuteScheduledServers";
+
+function createSchedule(overrides: Partial<ScheduledServer> = {}): ScheduledServer {
+    return {
+        id: "schedule-1",
+        userId: "user-1",
+        guildId: null,
+        region: "sa-saopaulo-1" as Region,
+        variant: "standard-competitive" as const,
+        scheduledAt: new Date("2026-08-01T21:30:00Z"),
+        triggerAt: new Date("2026-08-01T21:25:00Z"),
+        status: "scheduled",
+        serverId: null,
+        timezone: "UTC",
+        createdAt: new Date("2026-08-01T10:00:00Z"),
+        updatedAt: new Date("2026-08-01T10:00:00Z"),
+        ...overrides,
+    };
+}
+
+describe("ExecuteScheduledServers", () => {
+    let scheduledServerRepository: ReturnType<typeof mock<ScheduledServerRepository>>;
+    let backgroundTaskQueue: ReturnType<typeof mock<BackgroundTaskQueue>>;
+    let discordBot: ReturnType<typeof mock<DiscordClient>>;
+    let eventLogger: ReturnType<typeof mock<EventLogger>>;
+    let user: ReturnType<typeof mock<User>>;
+    let sut: ExecuteScheduledServers;
+
+    beforeEach(() => {
+        scheduledServerRepository = mock<ScheduledServerRepository>();
+        backgroundTaskQueue = mock<BackgroundTaskQueue>();
+        const users = mock<UserManager>();
+        discordBot = mock<DiscordClient>({ users });
+        eventLogger = mock<EventLogger>();
+        user = mock<User>();
+
+        users.fetch.mockResolvedValue(user);
+        user.send.mockResolvedValue(undefined as any);
+        scheduledServerRepository.findStuckCreating.mockResolvedValue([]);
+        scheduledServerRepository.findDue.mockResolvedValue([]);
+
+        sut = new ExecuteScheduledServers({
+            scheduledServerRepository,
+            backgroundTaskQueue,
+            discordBot,
+            eventLogger,
+        });
+    });
+
+    it("should claim a due schedule and enqueue a create-scheduled-server task without blocking", async () => {
+        // Given
+        const schedule = createSchedule();
+        vi.useFakeTimers();
+        vi.setSystemTime(new Date("2026-08-01T21:26:00Z"));
+        scheduledServerRepository.findDue.mockResolvedValue([schedule]);
+        scheduledServerRepository.claimForProcessing.mockResolvedValue(true);
+
+        // When
+        await sut.execute();
+
+        // Then
+        expect(scheduledServerRepository.claimForProcessing).toHaveBeenCalledWith("schedule-1", expect.any(Date));
+        expect(backgroundTaskQueue.enqueue).toHaveBeenCalledWith(
+            "create-scheduled-server",
+            { scheduleId: "schedule-1" },
+            undefined,
+            undefined,
+            { ownerId: "user-1" }
+        );
+        // Creation is delegated to the background queue — the routine must not
+        // create the server itself nor send the creation DMs
+        expect(user.send).not.toHaveBeenCalled();
+        expect(scheduledServerRepository.markStatus).not.toHaveBeenCalled();
+
+        vi.useRealTimers();
+    });
+
+    it("should enqueue one create-scheduled-server task per due schedule", async () => {
+        // Given
+        const schedule1 = createSchedule({ id: "schedule-1" });
+        const schedule2 = createSchedule({ id: "schedule-2", userId: "user-2" });
+        vi.useFakeTimers();
+        vi.setSystemTime(new Date("2026-08-01T21:26:00Z"));
+        scheduledServerRepository.findDue.mockResolvedValue([schedule1, schedule2]);
+        scheduledServerRepository.claimForProcessing.mockResolvedValue(true);
+
+        // When
+        await sut.execute();
+
+        // Then
+        expect(backgroundTaskQueue.enqueue).toHaveBeenCalledTimes(2);
+        expect(backgroundTaskQueue.enqueue).toHaveBeenNthCalledWith(1, "create-scheduled-server", { scheduleId: "schedule-1" }, undefined, undefined, { ownerId: "user-1" });
+        expect(backgroundTaskQueue.enqueue).toHaveBeenNthCalledWith(2, "create-scheduled-server", { scheduleId: "schedule-2" }, undefined, undefined, { ownerId: "user-2" });
+
+        vi.useRealTimers();
+    });
+
+    it("should skip schedules that could not be claimed (overlapping tick)", async () => {
+        // Given
+        const schedule = createSchedule();
+        vi.useFakeTimers();
+        vi.setSystemTime(new Date("2026-08-01T21:26:00Z"));
+        scheduledServerRepository.findDue.mockResolvedValue([schedule]);
+        scheduledServerRepository.claimForProcessing.mockResolvedValue(false);
+
+        // When
+        await sut.execute();
+
+        // Then
+        expect(backgroundTaskQueue.enqueue).not.toHaveBeenCalled();
+        expect(scheduledServerRepository.markStatus).not.toHaveBeenCalled();
+
+        vi.useRealTimers();
+    });
+
+    it("should mark stuck creating schedules as failed and DM the user", async () => {
+        // Given
+        const stuck = createSchedule({ id: "stuck-1", status: "creating", updatedAt: new Date(Date.now() - 21 * 60 * 1000) });
+        scheduledServerRepository.findStuckCreating.mockResolvedValue([stuck]);
+
+        // When
+        await sut.execute();
+
+        // Then
+        expect(scheduledServerRepository.markStatus).toHaveBeenCalledWith("stuck-1", "failed", undefined, expect.any(Date));
+        expect(user.send).toHaveBeenCalledTimes(1);
+        expect(user.send).toHaveBeenCalledWith(expect.stringContaining("did not complete"));
+        expect(eventLogger.log).toHaveBeenCalled();
+    });
+
+    it("should mark a schedule failed with the offline DM when past the grace period", async () => {
+        // Given
+        vi.useFakeTimers();
+        vi.setSystemTime(new Date("2026-08-01T22:30:00Z"));
+        const schedule = createSchedule({ triggerAt: new Date("2026-08-01T21:25:00Z") });
+        scheduledServerRepository.findDue.mockResolvedValue([schedule]);
+
+        // When
+        await sut.execute();
+
+        // Then
+        expect(scheduledServerRepository.markStatus).toHaveBeenCalledWith("schedule-1", "failed", undefined, expect.any(Date));
+        expect(user.send).toHaveBeenCalledTimes(1);
+        expect(user.send).toHaveBeenCalledWith(expect.stringContaining("bot was offline"));
+        expect(scheduledServerRepository.claimForProcessing).not.toHaveBeenCalled();
+        expect(backgroundTaskQueue.enqueue).not.toHaveBeenCalled();
+
+        vi.useRealTimers();
+    });
+});

--- a/packages/core/src/usecase/ExecuteScheduledServers.ts
+++ b/packages/core/src/usecase/ExecuteScheduledServers.ts
@@ -1,0 +1,55 @@
+import { Client } from "discord.js";
+import { ScheduledServerRepository } from "../repository/ScheduledServerRepository";
+import { EventLogger } from "../services/EventLogger";
+import { BackgroundTaskQueue } from "../services/BackgroundTaskQueue";
+import { failSafeDirectMessage } from "../utils/failSafeDirectMessage";
+
+const STUCK_CREATING_THRESHOLD_MS = 20 * 60 * 1000; // 20 minutes
+const GRACE_PERIOD_MS = 30 * 60 * 1000; // 30 minutes
+
+export class ExecuteScheduledServers {
+
+    constructor(private readonly dependencies: {
+        scheduledServerRepository: ScheduledServerRepository,
+        backgroundTaskQueue: BackgroundTaskQueue,
+        discordBot: Client,
+        eventLogger: EventLogger,
+    }) { }
+
+    public async execute(): Promise<void> {
+        const { scheduledServerRepository, backgroundTaskQueue, discordBot, eventLogger } = this.dependencies;
+        const now = new Date();
+
+        // Recover schedules stuck in 'creating' (bot restarted/crashed mid-creation)
+        const stuckBefore = new Date(now.getTime() - STUCK_CREATING_THRESHOLD_MS);
+        const stuck = await scheduledServerRepository.findStuckCreating(stuckBefore);
+        for (const schedule of stuck) {
+            await scheduledServerRepository.markStatus(schedule.id, "failed", undefined, now);
+            await failSafeDirectMessage(discordBot, schedule.userId, 'Your scheduled server creation did not complete (the bot restarted mid-creation). Please check /get-my-servers and schedule again if needed.');
+            await eventLogger.log({
+                actorId: schedule.userId,
+                eventMessage: `Scheduled server ${schedule.id} marked as failed after being stuck in creating for over 20 minutes.`
+            });
+        }
+
+        // Process due schedules
+        const due = await scheduledServerRepository.findDue(now);
+        for (const schedule of due) {
+            // Bot was offline past the trigger time + grace period
+            if (now.getTime() - schedule.triggerAt.getTime() > GRACE_PERIOD_MS) {
+                await scheduledServerRepository.markStatus(schedule.id, "failed", undefined, now);
+                await failSafeDirectMessage(discordBot, schedule.userId, 'Your scheduled time has already passed and the bot was offline — please schedule again.');
+                continue;
+            }
+
+            const claimed = await scheduledServerRepository.claimForProcessing(schedule.id, now);
+            if (!claimed) {
+                continue;
+            }
+
+            // Enqueue the creation as a background task — the routine must not block
+            // on it, since each creation can take several minutes
+            await backgroundTaskQueue.enqueue('create-scheduled-server', { scheduleId: schedule.id }, undefined, undefined, { ownerId: schedule.userId });
+        }
+    }
+}

--- a/packages/core/src/usecase/GetUserSchedules.test.ts
+++ b/packages/core/src/usecase/GetUserSchedules.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it, vi } from "vitest";
+import { mock } from "vitest-mock-extended";
+import { Region } from "../domain/Region";
+import { ScheduledServer } from "../domain/ScheduledServer";
+import { ScheduledServerRepository } from "../repository/ScheduledServerRepository";
+import { GetUserSchedules } from "./GetUserSchedules";
+
+function createSchedule(overrides: Partial<ScheduledServer> = {}): ScheduledServer {
+    return {
+        id: "schedule-1",
+        userId: "user-1",
+        guildId: null,
+        region: "sa-saopaulo-1" as Region,
+        variant: "standard-competitive" as const,
+        scheduledAt: new Date("2026-08-01T21:30:00Z"),
+        triggerAt: new Date("2026-08-01T21:25:00Z"),
+        status: "scheduled",
+        serverId: null,
+        timezone: "UTC",
+        createdAt: new Date("2026-08-01T10:00:00Z"),
+        updatedAt: new Date("2026-08-01T10:00:00Z"),
+        ...overrides,
+    };
+}
+
+describe("GetUserSchedules", () => {
+    it("should return the repository rows in the repository's order", async () => {
+        // Given
+        const scheduledServerRepository = mock<ScheduledServerRepository>();
+        const schedules = [
+            createSchedule({ id: "schedule-1", scheduledAt: new Date("2026-08-02T21:30:00Z") }),
+            createSchedule({ id: "schedule-2", status: "creating", scheduledAt: new Date("2026-08-01T21:30:00Z") }),
+        ];
+        scheduledServerRepository.findActiveByUserId.mockResolvedValue(schedules);
+        const sut = new GetUserSchedules({ scheduledServerRepository });
+
+        // When
+        const result = await sut.execute({ userId: "user-1" });
+
+        // Then
+        expect(scheduledServerRepository.findActiveByUserId).toHaveBeenCalledWith("user-1");
+        // The repository contract guarantees scheduledAt ASC ordering, so the use case passes rows through unchanged
+        expect(result).toEqual(schedules);
+    });
+
+    it("should pass through an empty result", async () => {
+        // Given
+        const scheduledServerRepository = mock<ScheduledServerRepository>();
+        scheduledServerRepository.findActiveByUserId.mockResolvedValue([]);
+        const sut = new GetUserSchedules({ scheduledServerRepository });
+
+        // When
+        const result = await sut.execute({ userId: "user-1" });
+
+        // Then
+        expect(result).toEqual([]);
+    });
+});

--- a/packages/core/src/usecase/GetUserSchedules.ts
+++ b/packages/core/src/usecase/GetUserSchedules.ts
@@ -1,0 +1,19 @@
+import { ScheduledServer } from "../domain";
+import { ScheduledServerRepository } from "../repository/ScheduledServerRepository";
+
+type GetUserSchedulesParams = {
+    userId: string;
+}
+
+export class GetUserSchedules {
+    constructor(private readonly dependencies: {
+        scheduledServerRepository: ScheduledServerRepository;
+    }) { }
+
+    async execute(params: GetUserSchedulesParams): Promise<ScheduledServer[]> {
+        const { scheduledServerRepository } = this.dependencies;
+        const { userId } = params;
+
+        return scheduledServerRepository.findActiveByUserId(userId);
+    }
+}

--- a/packages/core/src/utils/failSafeDirectMessage.test.ts
+++ b/packages/core/src/utils/failSafeDirectMessage.test.ts
@@ -1,0 +1,63 @@
+import { Client as DiscordClient, User, UserManager } from "discord.js";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { mock } from "vitest-mock-extended";
+import { logger } from "@tf2qs/telemetry";
+import { failSafeDirectMessage } from "./failSafeDirectMessage";
+
+vi.mock("@tf2qs/telemetry", async () => {
+    const actual = await vi.importActual("@tf2qs/telemetry");
+    return {
+        ...actual,
+        logger: {
+            emit: vi.fn(),
+        },
+    };
+});
+
+describe("failSafeDirectMessage", () => {
+    let discordBot: ReturnType<typeof mock<DiscordClient>>;
+    let users: ReturnType<typeof mock<UserManager>>;
+    let user: ReturnType<typeof mock<User>>;
+
+    beforeEach(() => {
+        users = mock<UserManager>();
+        discordBot = mock<DiscordClient>({ users });
+        user = mock<User>();
+        users.fetch.mockResolvedValue(user);
+        user.send.mockResolvedValue(undefined as any);
+        vi.mocked(logger.emit).mockClear();
+    });
+
+    it("should fetch the user and send the message on success", async () => {
+        // When
+        await failSafeDirectMessage(discordBot, "user-1", "hello");
+
+        // Then
+        expect(discordBot.users.fetch).toHaveBeenCalledWith("user-1");
+        expect(user.send).toHaveBeenCalledWith("hello");
+        expect(logger.emit).not.toHaveBeenCalled();
+    });
+
+    it("should log and resolve when fetching the user fails", async () => {
+        // Given
+        users.fetch.mockRejectedValue(new Error("Cannot send messages to this user"));
+
+        // When
+        await expect(failSafeDirectMessage(discordBot, "user-1", "hello")).resolves.toBeUndefined();
+
+        // Then
+        expect(logger.emit).toHaveBeenCalledWith(expect.objectContaining({ severityText: "WARN", body: "Failed to send direct message" }));
+        expect(user.send).not.toHaveBeenCalled();
+    });
+
+    it("should log and resolve when sending the message fails", async () => {
+        // Given
+        user.send.mockRejectedValue(new Error("send failed"));
+
+        // When
+        await expect(failSafeDirectMessage(discordBot, "user-1", "hello")).resolves.toBeUndefined();
+
+        // Then
+        expect(logger.emit).toHaveBeenCalledWith(expect.objectContaining({ severityText: "WARN", body: "Failed to send direct message" }));
+    });
+});

--- a/packages/core/src/utils/failSafeDirectMessage.ts
+++ b/packages/core/src/utils/failSafeDirectMessage.ts
@@ -1,0 +1,12 @@
+import { Client } from "discord.js";
+import { logger } from '@tf2qs/telemetry';
+
+export async function failSafeDirectMessage(discordBot: Client, userId: string, message: string): Promise<void> {
+    try {
+        const user = await discordBot.users.fetch(userId);
+        await user.send(message);
+    } catch (error) {
+        // Fail silently — direct message delivery must never abort the caller's flow
+        logger.emit({ severityText: 'WARN', body: 'Failed to send direct message', attributes: { userId, error: JSON.stringify(error, Object.getOwnPropertyNames(error)) } });
+    }
+}

--- a/packages/core/src/utils/scheduleTime.test.ts
+++ b/packages/core/src/utils/scheduleTime.test.ts
@@ -1,0 +1,145 @@
+import { describe, expect, it } from "vitest";
+import { UserError } from "../errors/UserError";
+import {
+    SCHEDULE_TIMEZONES,
+    isValidScheduleTime,
+    computeNextOccurrence,
+    formatDateTimeInTimeZone,
+    formatDurationUntil,
+} from "./scheduleTime";
+
+describe("scheduleTime", () => {
+
+    describe("SCHEDULE_TIMEZONES", () => {
+        it("should contain at most 25 entries (Discord choice limit)", () => {
+            expect(SCHEDULE_TIMEZONES.length).toBeLessThanOrEqual(25);
+        });
+
+        it("should include the timezones of every region the bot serves", () => {
+            expect(SCHEDULE_TIMEZONES).toContain("America/New_York");
+            expect(SCHEDULE_TIMEZONES).toContain("America/Chicago");
+            expect(SCHEDULE_TIMEZONES).toContain("America/Sao_Paulo");
+            expect(SCHEDULE_TIMEZONES).toContain("America/Argentina/Buenos_Aires");
+            expect(SCHEDULE_TIMEZONES).toContain("America/Bogota");
+            expect(SCHEDULE_TIMEZONES).toContain("Europe/Berlin");
+            expect(SCHEDULE_TIMEZONES).toContain("Australia/Sydney");
+        });
+    });
+
+    describe("isValidScheduleTime", () => {
+        it("should accept valid 24h times", () => {
+            expect(isValidScheduleTime("00:00")).toBe(true);
+            expect(isValidScheduleTime("09:05")).toBe(true);
+            expect(isValidScheduleTime("21:30")).toBe(true);
+            expect(isValidScheduleTime("23:59")).toBe(true);
+        });
+
+        it("should reject invalid times", () => {
+            expect(isValidScheduleTime("24:00")).toBe(false);
+            expect(isValidScheduleTime("12:60")).toBe(false);
+            expect(isValidScheduleTime("9:30")).toBe(false);
+            expect(isValidScheduleTime("21:3")).toBe(false);
+            expect(isValidScheduleTime("abc")).toBe(false);
+            expect(isValidScheduleTime("21:30:00")).toBe(false);
+            expect(isValidScheduleTime("")).toBe(false);
+        });
+    });
+
+    describe("computeNextOccurrence", () => {
+        it("should compute the occurrence for a valid time on the same day", () => {
+            // Given a fixed now before 21:30 UTC
+            const now = new Date("2026-08-01T10:00:00Z");
+            // When
+            const result = computeNextOccurrence({ time: "21:30", timezone: "UTC", now });
+            // Then
+            expect(result.toISOString()).toBe("2026-08-01T21:30:00.000Z");
+        });
+
+        it("should roll past times forward to tomorrow", () => {
+            // Given a fixed now after 21:30 UTC
+            const now = new Date("2026-08-01T22:00:00Z");
+            // When
+            const result = computeNextOccurrence({ time: "21:30", timezone: "UTC", now });
+            // Then
+            expect(result.toISOString()).toBe("2026-08-02T21:30:00.000Z");
+        });
+
+        it("should roll across month and year boundaries", () => {
+            // Given a fixed now on Dec 31, 2026 at 23:00 UTC
+            const now = new Date("2026-12-31T23:00:00Z");
+            // When
+            const result = computeNextOccurrence({ time: "21:30", timezone: "UTC", now });
+            // Then
+            expect(result.toISOString()).toBe("2027-01-01T21:30:00.000Z");
+        });
+
+        it("should resolve a nonexistent local time on spring-forward to the shifted instant (deterministic)", () => {
+            // America/New_York springs forward 2026-03-08 at 02:00 → 03:00.
+            // 02:30 on that date does not exist; deterministic resolution shifts to the instant whose wall clock reads 03:30.
+            const now = new Date("2026-03-08T00:00:00Z");
+            const result = computeNextOccurrence({ time: "02:30", timezone: "America/New_York", now });
+            // When the DST gap is 1h, the shifted instant is 07:30Z (wall 03:30 EDT)
+            expect(result.toISOString()).toBe("2026-03-08T07:30:00.000Z");
+        });
+
+        it("should resolve an ambiguous local time on fall-back to the first occurrence", () => {
+            // Europe/London falls back 2026-10-25 at 02:00 → 01:00. 01:30 occurs twice.
+            const now = new Date("2026-10-25T00:00:00Z");
+            const result = computeNextOccurrence({ time: "01:30", timezone: "Europe/London", now });
+            // First occurrence is 00:30Z (BST still active)
+            expect(result.toISOString()).toBe("2026-10-25T00:30:00.000Z");
+        });
+
+        it("should support the UTC timezone", () => {
+            const now = new Date("2026-08-01T10:00:00Z");
+            const result = computeNextOccurrence({ time: "11:15", timezone: "UTC", now });
+            expect(result.toISOString()).toBe("2026-08-01T11:15:00.000Z");
+        });
+
+        it("should throw UserError for an invalid time", () => {
+            const now = new Date("2026-08-01T10:00:00Z");
+            expect(() => computeNextOccurrence({ time: "25:99", timezone: "UTC", now }))
+                .toThrow(UserError);
+        });
+
+        it("should throw UserError for an invalid timezone", () => {
+            const now = new Date("2026-08-01T10:00:00Z");
+            expect(() => computeNextOccurrence({ time: "21:30", timezone: "Not/A_Timezone", now }))
+                .toThrow(UserError);
+        });
+
+        it("should default now to the current time when not provided", () => {
+            // Just assert it does not throw and returns a future instant
+            const result = computeNextOccurrence({ time: "21:30", timezone: "UTC" });
+            expect(result.getTime()).toBeGreaterThan(Date.now());
+        });
+    });
+
+    describe("formatDateTimeInTimeZone", () => {
+        it("should render a date in the given timezone", () => {
+            const date = new Date("2026-08-03T21:30:00Z");
+            const result = formatDateTimeInTimeZone(date, "UTC");
+            expect(result).toBe("Mon, Aug 3, 2026 at 21:30");
+        });
+    });
+
+    describe("formatDurationUntil", () => {
+        it("should format a duration in hours and minutes", () => {
+            const now = new Date("2026-08-01T10:00:00Z");
+            const date = new Date("2026-08-01T12:15:00Z");
+            expect(formatDurationUntil(date, now)).toBe("in 2h 15m");
+        });
+
+        it("should format a duration under a minute", () => {
+            const now = new Date("2026-08-01T10:00:00Z");
+            const date = new Date("2026-08-01T10:00:30Z");
+            expect(formatDurationUntil(date, now)).toBe("in less than a minute");
+        });
+
+        it("should return overdue for past dates", () => {
+            const now = new Date("2026-08-01T10:00:00Z");
+            const date = new Date("2026-08-01T09:00:00Z");
+            expect(formatDurationUntil(date, now)).toBe("overdue");
+        });
+    });
+});

--- a/packages/core/src/utils/scheduleTime.ts
+++ b/packages/core/src/utils/scheduleTime.ts
@@ -1,0 +1,227 @@
+import { UserError } from "../errors/UserError";
+
+export const SCHEDULE_TIMEZONES: readonly string[] = [
+    "UTC",
+    "America/New_York",
+    "America/Chicago",
+    "America/Denver",
+    "America/Los_Angeles",
+    "America/Sao_Paulo",
+    "America/Argentina/Buenos_Aires",
+    "America/Bogota",
+    "Europe/London",
+    "Europe/Lisbon",
+    "Europe/Madrid",
+    "Europe/Paris",
+    "Europe/Berlin",
+    "Europe/Rome",
+    "Europe/Amsterdam",
+    "Europe/Warsaw",
+    "Europe/Moscow",
+    "Europe/Istanbul",
+    "Asia/Dubai",
+    "Asia/Kolkata",
+    "Asia/Bangkok",
+    "Asia/Singapore",
+    "Asia/Tokyo",
+    "Asia/Seoul",
+    "Australia/Sydney",
+];
+
+const TIME_PATTERN = /^([01]\d|2[0-3]):[0-5]\d$/;
+
+export function isValidScheduleTime(time: string): boolean {
+    return TIME_PATTERN.test(time);
+}
+
+type WallClockParts = {
+    year: number;
+    month: number;
+    day: number;
+    hour: number;
+    minute: number;
+    second: number;
+};
+
+function getWallClockParts(date: Date, timezone: string): WallClockParts {
+    const parts = new Intl.DateTimeFormat("en-US", {
+        timeZone: timezone,
+        year: "numeric",
+        month: "2-digit",
+        day: "2-digit",
+        hour: "2-digit",
+        minute: "2-digit",
+        second: "2-digit",
+        hourCycle: "h23",
+    }).formatToParts(date);
+    const get = (type: string): number => {
+        const part = parts.find(p => p.type === type);
+        return part ? Number(part.value) : 0;
+    };
+    return {
+        year: get("year"),
+        month: get("month"),
+        day: get("day"),
+        hour: get("hour"),
+        minute: get("minute"),
+        second: get("second"),
+    };
+}
+
+/**
+ * Converts a wall-clock time (y, mo, d, h, m) in `timezone` to the UTC instant
+ * it represents.
+ *
+ * DST boundary behavior (deterministic):
+ * - Ambiguous local times (fall-back) resolve to the first occurrence.
+ * - Nonexistent local times (spring-forward) resolve to the shifted instant
+ *   (the wall clock reads the target time plus the DST gap).
+ */
+function wallClockToUtc(
+    year: number,
+    month: number,
+    day: number,
+    hour: number,
+    minute: number,
+    timezone: string,
+    reference: Date,
+): Date {
+    const naive = Date.UTC(year, month - 1, day, hour, minute, 0, 0);
+
+    // Seed the offset from the reference instant's wall clock so ambiguous
+    // times resolve to the first occurrence.
+    const referenceWall = getWallClockParts(reference, timezone);
+    let offset = reference.getTime() - Date.UTC(
+        referenceWall.year,
+        referenceWall.month - 1,
+        referenceWall.day,
+        referenceWall.hour,
+        referenceWall.minute,
+        referenceWall.second,
+        0,
+    );
+    let candidate = naive + offset;
+    let previousCandidate: number | null = null;
+    const seen = new Set<number>();
+
+    while (!seen.has(candidate)) {
+        seen.add(candidate);
+        const wall = getWallClockParts(new Date(candidate), timezone);
+        const wallAsUtc = Date.UTC(wall.year, wall.month - 1, wall.day, wall.hour, wall.minute, wall.second, 0);
+        if (wallAsUtc === naive) {
+            return new Date(candidate);
+        }
+        previousCandidate = candidate;
+        candidate = naive + candidate - wallAsUtc;
+    }
+
+    // The candidate oscillates between the two instants flanking a DST gap
+    // (nonexistent local time). Resolve to the forward-shifted instant: the
+    // one whose wall clock reads later than the requested time.
+    const previousWall = getWallClockParts(new Date(previousCandidate ?? candidate), timezone);
+    const previousWallAsUtc = Date.UTC(previousWall.year, previousWall.month - 1, previousWall.day, previousWall.hour, previousWall.minute, previousWall.second, 0);
+    const currentWall = getWallClockParts(new Date(candidate), timezone);
+    const currentWallAsUtc = Date.UTC(currentWall.year, currentWall.month - 1, currentWall.day, currentWall.hour, currentWall.minute, currentWall.second, 0);
+
+    if (previousWallAsUtc > naive) {
+        return new Date(previousCandidate ?? candidate);
+    }
+    return new Date(candidate);
+}
+
+export function computeNextOccurrence(args: {
+    time: string;
+    timezone: string;
+    now?: Date;
+}): Date {
+    const { time, timezone } = args;
+    const reference = args.now ?? new Date();
+
+    if (!isValidScheduleTime(time)) {
+        throw new UserError(`Invalid time: ${time}. Please use HH:mm in 24-hour format (e.g. 21:30).`);
+    }
+    if (!SCHEDULE_TIMEZONES.includes(timezone)) {
+        throw new UserError(`Invalid timezone: ${timezone}. Please select one of the supported timezones.`);
+    }
+
+    const [hour, minute] = time.split(":").map(Number);
+    const referenceWall = getWallClockParts(reference, timezone);
+
+    let candidate = wallClockToUtc(
+        referenceWall.year,
+        referenceWall.month,
+        referenceWall.day,
+        hour,
+        minute,
+        timezone,
+        reference,
+    );
+
+    // If the candidate is not in the future, roll forward to the next wall day
+    // (Date.UTC handles month/year rollover).
+    if (candidate.getTime() <= reference.getTime()) {
+        const nextDay = new Date(Date.UTC(referenceWall.year, referenceWall.month - 1, referenceWall.day + 1));
+        candidate = wallClockToUtc(
+            nextDay.getUTCFullYear(),
+            nextDay.getUTCMonth() + 1,
+            nextDay.getUTCDate(),
+            hour,
+            minute,
+            timezone,
+            reference,
+        );
+    }
+
+    // Safety net: the result should always be a valid, future instant.
+    if (Number.isNaN(candidate.getTime())) {
+        throw new UserError(`Could not compute a schedule time for ${time} in ${timezone}.`);
+    }
+
+    return candidate;
+}
+
+export function formatDateTimeInTimeZone(
+    date: Date,
+    timezone: string,
+    options?: Intl.DateTimeFormatOptions,
+): string {
+    const parts = new Intl.DateTimeFormat("en-US", {
+        timeZone: timezone,
+        weekday: "short",
+        month: "short",
+        day: "numeric",
+        year: "numeric",
+        hour: "2-digit",
+        minute: "2-digit",
+        hourCycle: "h23",
+        ...options,
+    }).formatToParts(date);
+    const get = (type: string): string => {
+        const part = parts.find(p => p.type === type);
+        return part ? part.value : "";
+    };
+    return `${get("weekday")}, ${get("month")} ${get("day")}, ${get("year")} at ${get("hour")}:${get("minute")}`;
+}
+
+export function formatDurationUntil(date: Date, now: Date): string {
+    const diffMs = date.getTime() - now.getTime();
+    if (diffMs < 0) {
+        return "overdue";
+    }
+    if (diffMs === 0) {
+        return "now";
+    }
+    if (diffMs < 60_000) {
+        return "in less than a minute";
+    }
+    const totalMinutes = Math.floor(diffMs / 60_000);
+    const hours = Math.floor(totalMinutes / 60);
+    const minutes = totalMinutes % 60;
+    if (hours > 0 && minutes > 0) {
+        return `in ${hours}h ${minutes}m`;
+    }
+    if (hours > 0) {
+        return `in ${hours}h`;
+    }
+    return `in ${minutes}m`;
+}

--- a/packages/entrypoints/src/commands/CancelSchedule/definition.ts
+++ b/packages/entrypoints/src/commands/CancelSchedule/definition.ts
@@ -1,0 +1,5 @@
+import { SlashCommandBuilder } from "discord.js";
+
+export const cancelScheduleCommandDefinition = new SlashCommandBuilder()
+    .setName('cancel-schedule')
+    .setDescription('Cancels your scheduled server');

--- a/packages/entrypoints/src/commands/CancelSchedule/handler.test.ts
+++ b/packages/entrypoints/src/commands/CancelSchedule/handler.test.ts
@@ -1,0 +1,74 @@
+import { Chance } from "chance";
+import { ChatInputCommandInteraction, MessageFlags } from "discord.js";
+import { describe, expect, it, vi } from "vitest";
+import { mock } from "vitest-mock-extended";
+import { when } from "vitest-when";
+import { CancelScheduledServer, Region, ScheduledServer, UserError } from "@tf2qs/core";
+import { cancelScheduleCommandHandlerFactory } from "./handler";
+
+describe("cancelScheduleCommandHandler", () => {
+    const chance = new Chance();
+
+    const createHandler = () => {
+        const interaction = mock<ChatInputCommandInteraction>();
+        interaction.options = mock();
+        interaction.user.id = chance.guid();
+        interaction.deferReply = vi.fn().mockResolvedValue(undefined) as any;
+        interaction.followUp = vi.fn().mockResolvedValue(undefined) as any;
+
+        const cancelScheduledServer = mock<CancelScheduledServer>();
+        const handler = cancelScheduleCommandHandlerFactory({ cancelScheduledServer });
+
+        return { interaction, cancelScheduledServer, handler };
+    };
+
+    const createCancelled = (): ScheduledServer => mock<ScheduledServer>({
+        id: chance.guid(),
+        userId: "user-1",
+        region: "sa-saopaulo-1" as Region,
+        variant: "standard-competitive",
+        scheduledAt: new Date("2026-08-01T21:30:00Z"),
+        status: "cancelled",
+        timezone: "America/New_York",
+    });
+
+    it("should cancel the schedule and confirm via followUp", async () => {
+        const { handler, interaction, cancelScheduledServer } = createHandler();
+        const cancelled = createCancelled();
+        when(cancelScheduledServer.execute).calledWith({ userId: interaction.user.id }).thenResolve(cancelled);
+
+        await handler(interaction);
+
+        expect(interaction.deferReply).toHaveBeenCalledWith({ flags: MessageFlags.Ephemeral });
+        expect(interaction.followUp).toHaveBeenCalledWith({
+            content: expect.stringContaining("Schedule cancelled"),
+            flags: MessageFlags.Ephemeral,
+        });
+    });
+
+    it("should call commandErrorHandler on UserError", async () => {
+        const { handler, interaction, cancelScheduledServer } = createHandler();
+        when(cancelScheduledServer.execute).calledWith({ userId: interaction.user.id })
+            .thenReject(new UserError("You don't have an active scheduled server."));
+
+        await handler(interaction);
+
+        expect(interaction.followUp).toHaveBeenCalledWith({
+            content: "You don't have an active scheduled server.",
+            flags: MessageFlags.Ephemeral,
+        });
+    });
+
+    it("should call commandErrorHandler on unexpected errors", async () => {
+        const { handler, interaction, cancelScheduledServer } = createHandler();
+        when(cancelScheduledServer.execute).calledWith({ userId: interaction.user.id })
+            .thenReject(new Error("boom"));
+
+        await handler(interaction);
+
+        expect(interaction.followUp).toHaveBeenCalledWith({
+            content: "There was an unexpected error running the command. Please reach out to the App Administrator.",
+            flags: MessageFlags.Ephemeral,
+        });
+    });
+});

--- a/packages/entrypoints/src/commands/CancelSchedule/handler.ts
+++ b/packages/entrypoints/src/commands/CancelSchedule/handler.ts
@@ -1,0 +1,28 @@
+import { ChatInputCommandInteraction, MessageFlags } from "discord.js";
+import { CancelScheduledServer, getRegionDisplayName, getVariantConfig, formatDateTimeInTimeZone } from "@tf2qs/core";
+import { commandErrorHandler } from "../commandErrorHandler";
+
+export function cancelScheduleCommandHandlerFactory(dependencies: {
+    cancelScheduledServer: CancelScheduledServer;
+}) {
+    return async function cancelScheduleCommandHandler(interaction: ChatInputCommandInteraction) {
+        const userId = interaction.user.id;
+        const { cancelScheduledServer } = dependencies;
+
+        await interaction.deferReply({
+            flags: MessageFlags.Ephemeral
+        })
+
+        try {
+            const cancelled = await cancelScheduledServer.execute({ userId });
+            const regionDisplayName = getRegionDisplayName(cancelled.region);
+            const variantDisplayName = getVariantConfig(cancelled.variant).displayName ?? cancelled.variant;
+            await interaction.followUp({
+                content: `✅ **Schedule cancelled:** ${regionDisplayName} · ${variantDisplayName} · ${formatDateTimeInTimeZone(cancelled.scheduledAt, cancelled.timezone)} (${cancelled.timezone})`,
+                flags: MessageFlags.Ephemeral
+            });
+        } catch (error: Error | any) {
+            await commandErrorHandler(interaction, error);
+        }
+    }
+}

--- a/packages/entrypoints/src/commands/CancelSchedule/index.ts
+++ b/packages/entrypoints/src/commands/CancelSchedule/index.ts
@@ -1,0 +1,2 @@
+export { cancelScheduleCommandDefinition } from "./definition";
+export { cancelScheduleCommandHandlerFactory } from "./handler";

--- a/packages/entrypoints/src/commands/Schedule/definition.ts
+++ b/packages/entrypoints/src/commands/Schedule/definition.ts
@@ -1,0 +1,27 @@
+import { SlashCommandBuilder } from "discord.js";
+import { getRegions, getRegionDisplayName } from "@tf2qs/core";
+import { SCHEDULE_TIMEZONES } from "@tf2qs/core";
+
+export const scheduleCommandDefinition = new SlashCommandBuilder()
+    .setName('schedule')
+    .setDescription('Schedules a server to be created and ready at a specific time')
+    .addStringOption(option =>
+        option.setName('region')
+            .setDescription('Region to deploy the server')
+            .addChoices(getRegions().map(region => ({
+                name: getRegionDisplayName(region),
+                value: region
+            })))
+            .setRequired(true)
+    )
+    .addStringOption(option =>
+        option.setName('time')
+            .setDescription('Ready time, 24h HH:mm (e.g. 21:30)')
+            .setRequired(true)
+    )
+    .addStringOption(option =>
+        option.setName('timezone')
+            .setDescription('Your timezone')
+            .addChoices(SCHEDULE_TIMEZONES.map(tz => ({ name: tz, value: tz })))
+            .setRequired(true)
+    );

--- a/packages/entrypoints/src/commands/Schedule/handler.test.ts
+++ b/packages/entrypoints/src/commands/Schedule/handler.test.ts
@@ -1,0 +1,193 @@
+import { Chance } from "chance";
+import { ChatInputCommandInteraction, Collection, InteractionCollector, Message, MessageComponentInteraction, MessageFlags } from "discord.js";
+import { describe, expect, it, vi } from "vitest";
+import { mock } from "vitest-mock-extended";
+import { when } from "vitest-when";
+import { CreateScheduledServer, Region, ScheduledServer, UserError } from "@tf2qs/core";
+import { createScheduleCommandHandlerFactory } from "./handler";
+
+describe("scheduleCommandHandler", () => {
+    const chance = new Chance();
+
+    const getTestRegion = () => "sa-saopaulo-1" as Region;
+
+    const createHandler = () => {
+        const interaction = mock<ChatInputCommandInteraction>();
+        interaction.options = mock();
+        interaction.user.id = chance.guid();
+        interaction.guildId = chance.guid();
+        Object.defineProperty(interaction, "channel", {
+            value: mock<any>(),
+            writable: false,
+        });
+
+        const message = mock<Message<boolean>>()
+        when(interaction.fetchReply).calledWith().thenResolve(message)
+        const collector = mock<InteractionCollector<any>>();
+        when(message.createMessageComponentCollector).calledWith(expect.anything()).thenReturn(collector);
+
+        const createScheduledServer = mock<CreateScheduledServer>();
+        const handler = createScheduleCommandHandlerFactory({
+            createScheduledServer,
+        });
+
+        return {
+            createScheduledServer,
+            interaction,
+            handler,
+            message,
+            collector,
+        };
+    };
+
+    const mockButtonInteraction = (interaction: ChatInputCommandInteraction, variantName: string) => {
+        const buttonInteraction = mock<MessageComponentInteraction>();
+        buttonInteraction.customId = `schedule-variant:${variantName}`;
+        buttonInteraction.user = interaction.user;
+        buttonInteraction.guildId = interaction.guildId;
+        buttonInteraction.deferReply = vi.fn().mockResolvedValue(undefined) as any;
+        buttonInteraction.followUp = vi.fn().mockResolvedValue(undefined) as any;
+        return buttonInteraction;
+    };
+
+    const setOptions = (interaction: ChatInputCommandInteraction, region: string, time: string, timezone: string) => {
+        when(interaction.options.getString).calledWith("region").thenReturn(region);
+        when(interaction.options.getString).calledWith("time").thenReturn(time);
+        when(interaction.options.getString).calledWith("timezone").thenReturn(timezone);
+    };
+
+    const collectCallbackOf = async (collector: ReturnType<typeof mock<InteractionCollector<any>>>, buttonInteraction: MessageComponentInteraction) => {
+        const collectCall = collector.on.mock.calls.find(call => call[0] === "collect");
+        if (!collectCall) throw new Error("Collect callback not found");
+        await collectCall[1](buttonInteraction);
+    };
+
+    it("should reply with an error for an invalid time format", async () => {
+        const { handler, interaction } = createHandler();
+        setOptions(interaction, getTestRegion(), "25:99", "UTC");
+        interaction.reply = vi.fn().mockResolvedValue(undefined) as any;
+
+        await handler(interaction);
+
+        expect(interaction.reply).toHaveBeenCalledWith({
+            content: expect.stringContaining("Invalid time"),
+            flags: MessageFlags.Ephemeral,
+        });
+    });
+
+    it("should call commandErrorHandler when scheduling fails on variant selection", async () => {
+        const { handler, interaction, createScheduledServer, collector } = createHandler();
+        const region = getTestRegion();
+        const time = "21:30";
+        const timezone = "UTC";
+        setOptions(interaction, region, time, timezone);
+        interaction.reply = vi.fn().mockResolvedValue(undefined) as any;
+
+        when(createScheduledServer.execute).calledWith(expect.anything()).thenReject(new UserError("You must enable DMs."));
+
+        await handler(interaction);
+
+        const buttonInteraction = mockButtonInteraction(interaction, "standard-competitive");
+        buttonInteraction.editReply = vi.fn().mockResolvedValue(undefined) as any;
+        await collectCallbackOf(collector, buttonInteraction);
+
+        expect(buttonInteraction.followUp).toHaveBeenCalledWith({
+            content: "You must enable DMs.",
+            flags: MessageFlags.Ephemeral,
+        });
+    });
+
+    it("should surface the already-have-a-schedule UserError from the use case on variant selection", async () => {
+        const { handler, interaction, createScheduledServer, collector } = createHandler();
+        const region = getTestRegion();
+        const time = "21:30";
+        const timezone = "America/New_York";
+        setOptions(interaction, region, time, timezone);
+        interaction.reply = vi.fn().mockResolvedValue(undefined) as any;
+
+        const alreadyScheduled = new UserError(
+            "You can only schedule one server at a time. You already have a schedule for Standard Competitive on Mon, Aug 3, 2026 at 17:30."
+        );
+        when(createScheduledServer.execute).calledWith(expect.anything()).thenReject(alreadyScheduled);
+
+        await handler(interaction);
+
+        const buttonInteraction = mockButtonInteraction(interaction, "standard-competitive");
+        buttonInteraction.editReply = vi.fn().mockResolvedValue(undefined) as any;
+        await collectCallbackOf(collector, buttonInteraction);
+
+        expect(buttonInteraction.followUp).toHaveBeenCalledWith({
+            content: "You can only schedule one server at a time. You already have a schedule for Standard Competitive on Mon, Aug 3, 2026 at 17:30.",
+            flags: MessageFlags.Ephemeral,
+        });
+    });
+
+    it("should reply with variant buttons and schedule on variant selection", async () => {
+        const { handler, interaction, createScheduledServer, collector } = createHandler();
+        const region = getTestRegion();
+        const time = "21:30";
+        const timezone = "America/New_York";
+        setOptions(interaction, region, time, timezone);
+        interaction.reply = vi.fn().mockResolvedValue(undefined) as any;
+
+        const scheduled = mock<ScheduledServer>({
+            id: "schedule-1",
+            userId: interaction.user.id,
+            region,
+            variant: "standard-competitive",
+            scheduledAt: new Date("2026-08-02T21:30:00Z"),
+            status: "scheduled",
+            timezone,
+        });
+        when(createScheduledServer.execute).calledWith({
+            userId: interaction.user.id,
+            guildId: interaction.guildId ?? undefined,
+            region,
+            variantName: "standard-competitive",
+            time,
+            timezone,
+        }).thenResolve(scheduled);
+
+        await handler(interaction);
+
+        const replyCall = (interaction.reply as any).mock.calls[0][0];
+        expect(replyCall.content).toContain("Server will be ready at");
+        expect(replyCall.components.length).toBeGreaterThan(0);
+
+        const buttonInteraction = mockButtonInteraction(interaction, "standard-competitive");
+        buttonInteraction.editReply = vi.fn().mockResolvedValue(undefined) as any;
+        await collectCallbackOf(collector, buttonInteraction);
+
+        expect(createScheduledServer.execute).toHaveBeenCalledWith({
+            userId: interaction.user.id,
+            guildId: interaction.guildId,
+            region,
+            variantName: "standard-competitive",
+            time,
+            timezone,
+        });
+        expect(buttonInteraction.deferReply).toHaveBeenCalled();
+        expect(buttonInteraction.followUp).toHaveBeenCalledWith({
+            content: expect.stringContaining("Server Scheduled!"),
+            flags: MessageFlags.Ephemeral,
+        });
+    });
+
+    it("should edit the reply with a timeout message when no variant is selected", async () => {
+        const { handler, interaction, collector } = createHandler();
+        setOptions(interaction, getTestRegion(), "21:30", "UTC");
+        interaction.reply = vi.fn().mockResolvedValue(undefined) as any;
+        interaction.editReply = vi.fn().mockResolvedValue(undefined) as any;
+
+        await handler(interaction);
+
+        const endCall = collector.on.mock.calls.find(call => call[0] === "end");
+        if (!endCall) throw new Error("End callback not found");
+        endCall[1](new Collection<string, MessageComponentInteraction>());
+
+        expect(interaction.editReply).toHaveBeenCalledWith({
+            content: expect.stringContaining("No variant selected"),
+            components: [],
+        });
+    });
+});

--- a/packages/entrypoints/src/commands/Schedule/handler.ts
+++ b/packages/entrypoints/src/commands/Schedule/handler.ts
@@ -1,0 +1,132 @@
+import { logger } from '@tf2qs/telemetry';
+import {
+    ChatInputCommandInteraction,
+    MessageFlags,
+    ActionRowBuilder,
+    ButtonBuilder,
+    ButtonStyle,
+    ComponentType,
+    MessageComponentInteraction,
+    Collection
+} from "discord.js";
+import { getVariantConfigs, getVariantConfig, getRegionDisplayName, Region } from "@tf2qs/core";
+import { CreateScheduledServer, ScheduledServer } from "@tf2qs/core";
+import { getScheduledCreationLeadMinutes } from "@tf2qs/core";
+import { computeNextOccurrence, formatDateTimeInTimeZone, formatDurationUntil, isValidScheduleTime } from "@tf2qs/core";
+import { commandErrorHandler } from "../commandErrorHandler";
+import { defaultGracefulShutdownManager } from "@tf2qs/providers";
+
+export function createScheduleCommandHandlerFactory(dependencies: {
+    createScheduledServer: CreateScheduledServer,
+}) {
+    return async function scheduleCommandHandler(interaction: ChatInputCommandInteraction) {
+        const { createScheduledServer } = dependencies;
+        const userId = interaction.user.id;
+        const region = interaction.options.getString('region') as Region;
+        const time = interaction.options.getString('time')!;
+        const timezone = interaction.options.getString('timezone')!;
+
+        // Validate the time format up-front
+        if (!isValidScheduleTime(time)) {
+            await interaction.reply({
+                content: 'Invalid time. Use HH:mm in 24h format (e.g. 21:30).',
+                flags: MessageFlags.Ephemeral
+            });
+            return;
+        }
+
+        // Build the preview using the same math as the use case
+        const now = new Date();
+        const scheduledAt = computeNextOccurrence({ time, timezone, now });
+        const triggerAt = new Date(scheduledAt.getTime() - getScheduledCreationLeadMinutes(region) * 60_000);
+        const regionDisplayName = getRegionDisplayName(region);
+
+        // Step 1: Show variant buttons
+        const allVariants = getVariantConfigs();
+        const guildSpecificVariants = allVariants.filter(variant =>
+            variant.config.guildId === interaction.guildId
+        );
+
+        const variants = guildSpecificVariants.length > 0
+            ? guildSpecificVariants
+            : allVariants.filter(variant => !variant.config.guildId);
+
+        const rows = [];
+        for (let i = 0; i < variants.length; i += 5) {
+            rows.push(new ActionRowBuilder<ButtonBuilder>().addComponents(
+                ...variants.slice(i, i + 5).map(variant =>
+                    new ButtonBuilder()
+                        .setCustomId(`schedule-variant:${variant.name}`)
+                        .setLabel(variant.config.displayName || variant.name)
+                        .setStyle(ButtonStyle.Primary)
+                )
+            ));
+        }
+
+        let variantDescriptions = variants.map(variant => {
+            const cfgs = variant.config.defaultCfgs
+                ? Object.entries(variant.config.defaultCfgs).map(([type, cfg]) => `${type}: ${cfg}`).join("\n")
+                : "";
+            return `**${variant.config.displayName || variant.name}**${cfgs ? `\nDefault CFGs:\n${cfgs}` : ""}`;
+        }).join("\n\n");
+
+        await interaction.reply({
+            content: `⏰ **Server will be ready at:** **${formatDateTimeInTimeZone(scheduledAt, timezone)}** (${timezone})\n` +
+                `🕐 (${formatDateTimeInTimeZone(scheduledAt, 'UTC')} UTC) — ${formatDurationUntil(scheduledAt, now)} from now\n\n` +
+                `Select a server variant to schedule in region **${regionDisplayName}**:` +
+                `\n\n${variantDescriptions}`,
+            components: rows,
+            flags: MessageFlags.Ephemeral
+        });
+
+        // Step 2: Wait for button interaction
+        const filter = (i: MessageComponentInteraction) =>
+            i.user.id === interaction.user.id && i.customId.startsWith('schedule-variant:');
+        const replyMessage = await interaction.fetchReply();
+        const collector = replyMessage.createMessageComponentCollector({
+            filter,
+            componentType: ComponentType.Button,
+            time: 30_000,
+            max: 1
+        });
+        collector.on('collect', async (buttonInteraction: MessageComponentInteraction) => {
+            await defaultGracefulShutdownManager.run(async () => {
+                try {
+                    await interaction.editReply({
+                        content: `You selected the variant: ${buttonInteraction.customId.split(':')[1]}. Processing your request...`,
+                        components: []
+                    })
+                } catch (error) {
+                    logger.emit({ severityText: 'ERROR', body: 'Error editing reply', attributes: { error: JSON.stringify(error, Object.getOwnPropertyNames(error)) } });
+                }
+                const variantName = buttonInteraction.customId.split(':')[1];
+                await buttonInteraction.deferReply({ flags: MessageFlags.Ephemeral });
+                try {
+                    const schedule: ScheduledServer = await createScheduledServer.execute({
+                        userId,
+                        guildId: interaction.guildId ?? undefined,
+                        region,
+                        variantName,
+                        time,
+                        timezone
+                    });
+                    const variantDisplayName = getVariantConfig(variantName).displayName ?? variantName;
+                    await buttonInteraction.followUp({
+                        content: `✅ **Server Scheduled!**\n` +
+                            `Region: **${getRegionDisplayName(region)}** · Variant: **${variantDisplayName}**\n` +
+                            `⏰ Ready at: **${formatDateTimeInTimeZone(schedule.scheduledAt, timezone)}** (${timezone})\n` +
+                            `🕐 (${formatDateTimeInTimeZone(schedule.scheduledAt, 'UTC')} UTC) — ${formatDurationUntil(schedule.scheduledAt, new Date())} from now`,
+                        flags: MessageFlags.Ephemeral
+                    });
+                } catch (error: Error | any) {
+                    await commandErrorHandler(buttonInteraction, error);
+                }
+            });
+        });
+        collector.on('end', (collected: Collection<string, MessageComponentInteraction>) => {
+            if (collected.size === 0) {
+                interaction.editReply({ content: 'No variant selected. Command timed out.', components: [] });
+            }
+        });
+    }
+}

--- a/packages/entrypoints/src/commands/Schedule/index.ts
+++ b/packages/entrypoints/src/commands/Schedule/index.ts
@@ -1,0 +1,2 @@
+export { scheduleCommandDefinition } from "./definition";
+export { createScheduleCommandHandlerFactory } from "./handler";

--- a/packages/entrypoints/src/commands/ShowSchedules/definition.ts
+++ b/packages/entrypoints/src/commands/ShowSchedules/definition.ts
@@ -1,0 +1,5 @@
+import { SlashCommandBuilder } from "discord.js";
+
+export const showSchedulesCommandDefinition = new SlashCommandBuilder()
+    .setName('show-schedules')
+    .setDescription('Shows your scheduled server(s)');

--- a/packages/entrypoints/src/commands/ShowSchedules/handler.test.ts
+++ b/packages/entrypoints/src/commands/ShowSchedules/handler.test.ts
@@ -1,0 +1,88 @@
+import { Chance } from "chance";
+import { ChatInputCommandInteraction, MessageFlags } from "discord.js";
+import { describe, expect, it, vi } from "vitest";
+import { mock } from "vitest-mock-extended";
+import { when } from "vitest-when";
+import { GetUserSchedules, Region, ScheduledServer } from "@tf2qs/core";
+import { showSchedulesCommandHandlerFactory } from "./handler";
+
+describe("showSchedulesCommandHandler", () => {
+    const chance = new Chance();
+
+    const createHandler = () => {
+        const interaction = mock<ChatInputCommandInteraction>();
+        interaction.options = mock();
+        interaction.user.id = chance.guid();
+        interaction.reply = vi.fn().mockResolvedValue(undefined) as any;
+
+        const getUserSchedules = mock<GetUserSchedules>();
+        const handler = showSchedulesCommandHandlerFactory({ getUserSchedules });
+
+        return { interaction, getUserSchedules, handler };
+    };
+
+    const createSchedule = (overrides: Partial<ScheduledServer> = {}): ScheduledServer => mock<ScheduledServer>({
+        id: chance.guid(),
+        userId: interactionUser(),
+        region: "sa-saopaulo-1" as Region,
+        variant: "standard-competitive",
+        scheduledAt: new Date("2026-08-01T21:30:00Z"),
+        status: "scheduled",
+        timezone: "UTC",
+        ...overrides,
+    });
+
+    const interactionUser = () => "user-1";
+
+    it("should reply with an empty state when there are no schedules", async () => {
+        const { handler, interaction, getUserSchedules } = createHandler();
+        when(getUserSchedules.execute).calledWith({ userId: interaction.user.id }).thenResolve([]);
+
+        await handler(interaction);
+
+        expect(interaction.reply).toHaveBeenCalledWith({
+            content: expect.stringContaining("don't have any scheduled servers"),
+            flags: MessageFlags.Ephemeral,
+        });
+    });
+
+    it("should reply with formatted schedule details", async () => {
+        const { handler, interaction, getUserSchedules } = createHandler();
+        const schedules = [createSchedule()];
+        when(getUserSchedules.execute).calledWith({ userId: interaction.user.id }).thenResolve(schedules);
+
+        await handler(interaction);
+
+        const replyCall = (interaction.reply as any).mock.calls[0][0];
+        expect(replyCall.content).toContain("Your Scheduled Servers");
+        expect(replyCall.content).toContain("Schedule 1");
+        expect(replyCall.content).toContain("Scheduled");
+        expect(replyCall.flags).toBe(MessageFlags.Ephemeral);
+    });
+
+    it("should reply with a too-many-schedules warning when the content is too long", async () => {
+        const { handler, interaction, getUserSchedules } = createHandler();
+        const schedules = Array.from({ length: 10 }, (_, i) => createSchedule({ id: `s${i}` }));
+        when(getUserSchedules.execute).calledWith({ userId: interaction.user.id }).thenResolve(schedules);
+
+        await handler(interaction);
+
+        expect(interaction.reply).toHaveBeenCalledWith({
+            content: expect.stringContaining("too many schedules"),
+            flags: MessageFlags.Ephemeral,
+        });
+    });
+
+    it("should call commandErrorHandler when the use case fails", async () => {
+        const { handler, interaction, getUserSchedules } = createHandler();
+        interaction.followUp = vi.fn().mockResolvedValue(undefined) as any;
+        when(getUserSchedules.execute).calledWith({ userId: interaction.user.id }).thenReject(new Error("db down"));
+
+        await handler(interaction);
+
+        expect(interaction.followUp).toHaveBeenCalledWith({
+            content: "There was an unexpected error running the command. Please reach out to the App Administrator.",
+            flags: MessageFlags.Ephemeral,
+        });
+    });
+});

--- a/packages/entrypoints/src/commands/ShowSchedules/handler.ts
+++ b/packages/entrypoints/src/commands/ShowSchedules/handler.ts
@@ -1,0 +1,48 @@
+import { ChatInputCommandInteraction, MessageFlags } from "discord.js";
+import { GetUserSchedules } from "@tf2qs/core";
+import { commandErrorHandler } from "../commandErrorHandler";
+import { formatScheduledServerMessage } from "../formatScheduledServerMessage";
+
+type ShowSchedulesCommandHandlerFactoryDependencies = {
+    getUserSchedules: GetUserSchedules;
+}
+
+export function showSchedulesCommandHandlerFactory(dependencies: ShowSchedulesCommandHandlerFactoryDependencies) {
+    return async function showSchedulesCommandHandler(interaction: ChatInputCommandInteraction) {
+        const { getUserSchedules } = dependencies;
+        const userId = interaction.user.id;
+
+        try {
+            const schedules = await getUserSchedules.execute({ userId });
+
+            if (schedules.length === 0) {
+                await interaction.reply({
+                    content: '📭 You don\'t have any scheduled servers.',
+                    flags: MessageFlags.Ephemeral
+                });
+                return;
+            }
+
+            const scheduleDetails = schedules.map((schedule, index) =>
+                formatScheduledServerMessage(schedule, index)
+            ).join('\n');
+
+            const content = `🗓️ **Your Scheduled Servers:**\n\n${scheduleDetails}`;
+
+            if (content.length > 2000) {
+                await interaction.reply({
+                    content: '⚠️ You have too many schedules to display at once. Please cancel some schedules and try again.',
+                    flags: MessageFlags.Ephemeral
+                });
+                return;
+            }
+
+            await interaction.reply({
+                content,
+                flags: MessageFlags.Ephemeral
+            });
+        } catch (error: Error | any) {
+            await commandErrorHandler(interaction, error);
+        }
+    }
+}

--- a/packages/entrypoints/src/commands/ShowSchedules/index.ts
+++ b/packages/entrypoints/src/commands/ShowSchedules/index.ts
@@ -1,0 +1,2 @@
+export { showSchedulesCommandDefinition } from "./definition";
+export { showSchedulesCommandHandlerFactory } from "./handler";

--- a/packages/entrypoints/src/commands/formatScheduledServerMessage.test.ts
+++ b/packages/entrypoints/src/commands/formatScheduledServerMessage.test.ts
@@ -1,0 +1,120 @@
+import { describe, expect, it } from "vitest";
+import { Region, ScheduledServer, ScheduledServerStatus } from "@tf2qs/core";
+import { formatScheduledServerMessage } from "./formatScheduledServerMessage";
+
+function createSchedule(overrides: Partial<ScheduledServer> = {}): ScheduledServer {
+    return {
+        id: "schedule-1",
+        userId: "user-1",
+        guildId: null,
+        region: "sa-saopaulo-1" as Region,
+        variant: "standard-competitive",
+        scheduledAt: new Date("2026-08-03T21:30:00Z"),
+        triggerAt: new Date("2026-08-03T21:25:00Z"),
+        status: "scheduled",
+        serverId: null,
+        timezone: "UTC",
+        createdAt: new Date("2026-08-01T10:00:00Z"),
+        updatedAt: new Date("2026-08-01T10:00:00Z"),
+        ...overrides,
+    };
+}
+
+describe("formatScheduledServerMessage", () => {
+
+    describe("status labels", () => {
+        it.each<[ScheduledServerStatus, string]>([
+            ["scheduled", "⏳ Scheduled"],
+            ["creating", "🛠️ Creating"],
+            ["created", "✅ Created"],
+            ["failed", "❌ Failed"],
+            ["cancelled", "🚫 Cancelled"],
+        ])("should render the label for the %s status", (status, label) => {
+            // Given
+            const schedule = createSchedule({ status });
+
+            // When
+            const message = formatScheduledServerMessage(schedule);
+
+            // Then
+            expect(message).toContain(label);
+        });
+
+        it("should only show a relative duration for the scheduled status", () => {
+            // Given
+            const scheduled = createSchedule({ status: "scheduled", scheduledAt: new Date("2099-08-03T21:30:00Z") });
+            const created = createSchedule({ status: "created" });
+
+            // When
+            const scheduledMessage = formatScheduledServerMessage(scheduled);
+            const createdMessage = formatScheduledServerMessage(created);
+
+            // Then
+            expect(scheduledMessage).toContain("from now");
+            expect(createdMessage).not.toContain("from now");
+        });
+    });
+
+    describe("index", () => {
+        it("should omit the schedule number when no index is provided", () => {
+            // When
+            const message = formatScheduledServerMessage(createSchedule());
+
+            // Then
+            expect(message).toContain("**São Paulo**");
+            expect(message).not.toContain("Schedule ");
+        });
+
+        it("should number the schedule starting from 1 when an index is provided", () => {
+            // When
+            const message = formatScheduledServerMessage(createSchedule(), 0);
+
+            // Then
+            expect(message).toContain("**Schedule 1** (São Paulo)");
+        });
+
+        it("should use the 1-based index for the schedule number", () => {
+            // When
+            const message = formatScheduledServerMessage(createSchedule(), 3);
+
+            // Then
+            expect(message).toContain("**Schedule 4** (São Paulo)");
+        });
+    });
+
+    describe("times", () => {
+        it("should render the local timezone time and the UTC time", () => {
+            // Given
+            const schedule = createSchedule({ timezone: "America/New_York" });
+
+            // When
+            const message = formatScheduledServerMessage(schedule);
+
+            // Then
+            expect(message).toContain("Mon, Aug 3, 2026 at 17:30 (America/New_York)");
+            expect(message).toContain("🕐 (Mon, Aug 3, 2026 at 21:30 UTC)");
+        });
+
+        it("should show overdue when the scheduled time has already passed", () => {
+            // Given
+            const schedule = createSchedule({ scheduledAt: new Date("2020-08-03T21:30:00Z") });
+
+            // When
+            const message = formatScheduledServerMessage(schedule);
+
+            // Then
+            expect(message).toContain("(overdue from now)");
+        });
+    });
+
+    describe("display names", () => {
+        it("should render the region and variant display names", () => {
+            // When
+            const message = formatScheduledServerMessage(createSchedule());
+
+            // Then
+            expect(message).toContain("🌍 **Region:** `São Paulo`");
+            expect(message).toContain("🎮 **Variant:** `Standard Competitive`");
+        });
+    });
+});

--- a/packages/entrypoints/src/commands/formatScheduledServerMessage.ts
+++ b/packages/entrypoints/src/commands/formatScheduledServerMessage.ts
@@ -1,0 +1,27 @@
+import { ScheduledServer, getRegionDisplayName, getVariantConfig } from "@tf2qs/core";
+import { formatDateTimeInTimeZone, formatDurationUntil } from "@tf2qs/core";
+
+const STATUS_LABELS: Record<ScheduledServer['status'], string> = {
+    scheduled: '⏳ Scheduled',
+    creating: '🛠️ Creating',
+    created: '✅ Created',
+    failed: '❌ Failed',
+    cancelled: '🚫 Cancelled',
+};
+
+export function formatScheduledServerMessage(schedule: ScheduledServer, index?: number): string {
+    const regionDisplayName = getRegionDisplayName(schedule.region);
+    const variantDisplayName = getVariantConfig(schedule.variant).displayName ?? schedule.variant;
+    const scheduleNumber = index !== undefined ? `**Schedule ${index + 1}** (${regionDisplayName})` : `**${regionDisplayName}**`;
+    const now = new Date();
+    const relative = schedule.status === 'scheduled'
+        ? `(${formatDurationUntil(schedule.scheduledAt, now)} from now)`
+        : '';
+
+    return `${scheduleNumber}\n` +
+        `🌍 **Region:** \`${regionDisplayName}\`\n` +
+        `🎮 **Variant:** \`${variantDisplayName}\`\n` +
+        `📡 **Status:** ${STATUS_LABELS[schedule.status]}\n` +
+        `⏰ **Ready at:** ${formatDateTimeInTimeZone(schedule.scheduledAt, schedule.timezone)} (${schedule.timezone}) ${relative}\n` +
+        `🕐 (${formatDateTimeInTimeZone(schedule.scheduledAt, 'UTC')} UTC)`;
+}

--- a/packages/entrypoints/src/commands/index.ts
+++ b/packages/entrypoints/src/commands/index.ts
@@ -3,6 +3,9 @@ import { CreateServerForUser } from "@tf2qs/core";
 import { GetServerStatus } from "@tf2qs/core";
 import { GetGuildServers } from "@tf2qs/core";
 import { GetUserServers } from "@tf2qs/core";
+import { GetUserSchedules } from "@tf2qs/core";
+import { CreateScheduledServer } from "@tf2qs/core";
+import { CancelScheduledServer } from "@tf2qs/core";
 import { BackgroundTaskQueue } from "@tf2qs/core";
 import { createServerCommandDefinition, createServerCommandHandlerFactory } from "./CreateServer";
 import { getMyServersCommandDefinition, getMyServersCommandHandlerFactory } from "./GetMyServers";
@@ -11,6 +14,9 @@ import { terminateServerCommandDefinition, terminateServerHandlerFactory } from 
 import { setUserDataDefinition, setUserDataHandlerFactory } from "./SetUserData";
 import { SetUserData } from "@tf2qs/core";
 import { statusCommandDefinition, createStatusCommandHandlerFactory } from "./Status";
+import { scheduleCommandDefinition, createScheduleCommandHandlerFactory } from "./Schedule";
+import { showSchedulesCommandDefinition, showSchedulesCommandHandlerFactory } from "./ShowSchedules";
+import { cancelScheduleCommandDefinition, cancelScheduleCommandHandlerFactory } from "./CancelSchedule";
 
 export type CommandDependencies = {
     createServerForUser: CreateServerForUser;
@@ -19,6 +25,9 @@ export type CommandDependencies = {
     getServerStatus: GetServerStatus;
     getGuildServers: GetGuildServers;
     getUserServers: GetUserServers;
+    getUserSchedules: GetUserSchedules;
+    createScheduledServer: CreateScheduledServer;
+    cancelScheduledServer: CancelScheduledServer;
 }
 
 export function createCommands(dependencies: CommandDependencies) {
@@ -64,6 +73,27 @@ export function createCommands(dependencies: CommandDependencies) {
             definition: getMyServersCommandDefinition,
             handler: getMyServersCommandHandlerFactory({
                 getUserServers: dependencies.getUserServers,
+            })
+        },
+        schedule: {
+            name: "schedule",
+            definition: scheduleCommandDefinition,
+            handler: createScheduleCommandHandlerFactory({
+                createScheduledServer: dependencies.createScheduledServer,
+            })
+        },
+        showSchedules: {
+            name: "show-schedules",
+            definition: showSchedulesCommandDefinition,
+            handler: showSchedulesCommandHandlerFactory({
+                getUserSchedules: dependencies.getUserSchedules,
+            })
+        },
+        cancelSchedule: {
+            name: "cancel-schedule",
+            definition: cancelScheduleCommandDefinition,
+            handler: cancelScheduleCommandHandlerFactory({
+                cancelScheduledServer: dependencies.cancelScheduledServer,
             })
         }
     } satisfies Record<string, {

--- a/packages/entrypoints/src/discordBot.test.ts
+++ b/packages/entrypoints/src/discordBot.test.ts
@@ -2,8 +2,10 @@ import { Client, CommandInteraction, REST, Routes } from 'discord.js';
 import { beforeAll, describe, expect, it, vi } from 'vitest';
 import { mock, mockDeep } from "vitest-mock-extended";
 import { when } from "vitest-when";
-import { KnexConnectionManager } from '@tf2qs/providers';
+import { KnexConnectionManager, InMemoryBackgroundTaskQueue } from '@tf2qs/providers';
+import { CreateServerForUser, ExecuteScheduledServers } from "@tf2qs/core";
 import { createCommands } from './commands';
+import { scheduleScheduledServerCreationRoutine } from "./jobs";
 import { startDiscordBot } from "./discordBot";
 
 vi.mock("@tf2qs/providers", async () => {
@@ -27,6 +29,14 @@ vi.mock("./commands", async (importOriginal) => {
     const commands = actual.createCommands(mock() as any);
     return {
         createCommands: vi.fn().mockReturnValue(commands),
+    }
+})
+
+vi.mock("./jobs", async (importOriginal) => {
+    const actual = await importOriginal() as typeof import('./jobs');
+    return {
+        ...actual,
+        scheduleScheduledServerCreationRoutine: vi.fn(),
     }
 })
 
@@ -100,6 +110,36 @@ describe("startDiscordBot", () => {
 
         it("should set the token for the REST client", () => {
             expect(rest.setToken).toHaveBeenCalledWith('valid_token');
+        })
+
+        describe("scheduled server wiring", () => {
+            it("should schedule the scheduled server creation routine with an ExecuteScheduledServers use case", () => {
+                expect(scheduleScheduledServerCreationRoutine).toHaveBeenCalledWith({
+                    executeScheduledServers: expect.any(ExecuteScheduledServers),
+                    eventLogger: expect.anything(),
+                });
+            })
+
+            it("should pass the shared createServerForUser instance to createCommands", () => {
+                // startDiscordBot calls createCommands once; the first call is the module-scope mock
+                const lastCreateCommandsCall = vi.mocked(createCommands).mock.calls[vi.mocked(createCommands).mock.calls.length - 1];
+                const commandDependencies = lastCreateCommandsCall[0];
+                expect(commandDependencies.createServerForUser).toBeInstanceOf(CreateServerForUser);
+            })
+
+            it("should pass the backgroundTaskQueue to ExecuteScheduledServers", () => {
+                const jobDependencies = vi.mocked(scheduleScheduledServerCreationRoutine).mock.calls[0][0];
+                // The backgroundTaskQueue is constructed inside startDiscordBot (new
+                // InMemoryBackgroundTaskQueue(...)) and is not injectable or mockable at this
+                // boundary, so the only way to verify it was wired into ExecuteScheduledServers is
+                // to reach into its TS-private `dependencies` field. This guards against a
+                // regression where the routine is scheduled without a queue, which would silently
+                // drop all create-scheduled-server enqueues.
+                const executeScheduledServers = jobDependencies.executeScheduledServers as unknown as {
+                    dependencies: { backgroundTaskQueue: InMemoryBackgroundTaskQueue };
+                };
+                expect(executeScheduledServers.dependencies.backgroundTaskQueue).toBeInstanceOf(InMemoryBackgroundTaskQueue);
+            })
         })
 
         describe("interaction handlers", () => {

--- a/packages/entrypoints/src/discordBot.ts
+++ b/packages/entrypoints/src/discordBot.ts
@@ -1,6 +1,11 @@
 import { CreateServerForClient } from "@tf2qs/core";
 import { ChatInputCommandInteraction, Client, GatewayIntentBits, MessageFlags, REST, Routes } from "discord.js";
 import { CreateServerForUser } from "@tf2qs/core";
+import { CancelScheduledServer } from "@tf2qs/core";
+import { CreateScheduledServer } from "@tf2qs/core";
+import { ExecuteScheduledServers } from "@tf2qs/core";
+import { ExecuteScheduledServerCreation } from "@tf2qs/core";
+import { GetUserSchedules } from "@tf2qs/core";
 import { DeleteServer } from "@tf2qs/core";
 import { DeleteServerForUser } from "@tf2qs/core";
 import { GenerateMonthlyUsageReport } from "@tf2qs/core";
@@ -17,6 +22,7 @@ import { DefaultCostProvider } from "@tf2qs/providers";
 import { createServerForClientTaskProcessor } from "@tf2qs/providers";
 import { createDeleteServerForUserTaskProcessor } from "@tf2qs/providers";
 import { createDeleteServerTaskProcessor } from "@tf2qs/providers";
+import { createScheduledServerTaskProcessor } from "@tf2qs/providers";
 import { InMemoryBackgroundTaskQueue } from "@tf2qs/providers";
 import { CsvUserBanRepository } from "@tf2qs/providers";
 import { KnexConnectionManager } from "@tf2qs/providers";
@@ -24,6 +30,7 @@ import { SQLiteGuildParametersRepository } from "@tf2qs/providers";
 import { SQLiteReportRepository } from "@tf2qs/providers";
 import { SQLiteServerActivityRepository } from "@tf2qs/providers";
 import { SQLiteServerRepository } from "@tf2qs/providers";
+import { SQLiteScheduledServerRepository } from "@tf2qs/providers";
 import { SQLiteUserRepository } from "@tf2qs/providers";
 import { SQLiteServerStatusMetricsRepository } from "@tf2qs/providers";
 import { SQLitePlayerConnectionHistoryRepository } from "@tf2qs/providers";
@@ -41,8 +48,9 @@ import { defaultConfigManager } from "@tf2qs/providers";
 import { logger } from "@tf2qs/telemetry";
 import { createCommands } from "./commands";
 import { initializeExpress } from "./http/express";
-import { scheduleMonthlyUsageReportRoutine, schedulePendingServerCleanupRoutine, scheduleServerCleanupRoutine, scheduleTerminateLongRunningServerRoutine } from "./jobs";
+import { scheduleMonthlyUsageReportRoutine, schedulePendingServerCleanupRoutine, scheduleServerCleanupRoutine, scheduleScheduledServerCreationRoutine, scheduleTerminateLongRunningServerRoutine } from "./jobs";
 import { startSrcdsCommandListener } from "./udp/srcdsCommandListener";
+import { formatServerMessage } from "./commands/formatServerMessage";
 
 export async function startDiscordBot() {
 
@@ -153,17 +161,52 @@ export async function startDiscordBot() {
         createServerForClientTaskProcessor(createServerForClientUseCase)
     );
 
+    const createServerForUser = new CreateServerForUser({
+        serverManagerFactory: serverManagerFactory,
+        serverRepository,
+        eventLogger,
+        sourceTvEventLogger,
+        userRepository,
+        guildParametersRepository,
+        userBanRepository,
+        idGenerator: new UuidIdGenerator()
+    });
+
+    const scheduledServerRepository = new SQLiteScheduledServerRepository({
+        knex: KnexConnectionManager.client,
+    })
+
+    const executeScheduledServerCreation = new ExecuteScheduledServerCreation({
+        scheduledServerRepository,
+        createServerForUser,
+        discordBot: client,
+        eventLogger,
+        serverMessageFormatter: formatServerMessage,
+    });
+
+    backgroundTaskQueue.registerProcessor(
+        'create-scheduled-server',
+        createScheduledServerTaskProcessor(executeScheduledServerCreation)
+    );
+
+    const createScheduledServer = new CreateScheduledServer({
+        scheduledServerRepository,
+        idGenerator: new UuidIdGenerator(),
+        discordBot: client,
+        eventLogger
+    });
+
+    const getUserSchedules = new GetUserSchedules({
+        scheduledServerRepository
+    });
+
+    const cancelScheduledServer = new CancelScheduledServer({
+        scheduledServerRepository,
+        eventLogger
+    });
+
     const discordCommands = createCommands({
-        createServerForUser: new CreateServerForUser({
-            serverManagerFactory: serverManagerFactory,
-            serverRepository,
-            eventLogger,
-            sourceTvEventLogger,
-            userRepository,
-            guildParametersRepository,
-            userBanRepository,
-            idGenerator: new UuidIdGenerator()
-        }),
+        createServerForUser,
         setUserData: new SetUserData({
             userRepository
         }),
@@ -176,6 +219,9 @@ export async function startDiscordBot() {
         getUserServers: new GetUserServers({
             serverRepository
         }),
+        getUserSchedules,
+        createScheduledServer,
+        cancelScheduledServer,
         backgroundTaskQueue
     })
 
@@ -209,6 +255,18 @@ export async function startDiscordBot() {
             serverCommander,
             eventLogger
         }),
+        eventLogger
+    })
+
+    const executeScheduledServers = new ExecuteScheduledServers({
+        scheduledServerRepository,
+        backgroundTaskQueue,
+        discordBot: client,
+        eventLogger,
+    });
+
+    scheduleScheduledServerCreationRoutine({
+        executeScheduledServers,
         eventLogger
     })
 

--- a/packages/entrypoints/src/jobs/ScheduledServerCreationRoutine.test.ts
+++ b/packages/entrypoints/src/jobs/ScheduledServerCreationRoutine.test.ts
@@ -1,0 +1,54 @@
+import schedule from "node-schedule";
+import { describe, expect, it, vi } from "vitest";
+import { mock } from "vitest-mock-extended";
+import { EventLogger, ExecuteScheduledServers } from "@tf2qs/core";
+import { scheduleScheduledServerCreationRoutine } from "./ScheduledServerCreationRoutine";
+
+vi.mock("node-schedule")
+
+describe("ScheduledServerCreationRoutine", () => {
+
+    const makeSut = () => {
+        const scheduleMock = vi.mocked(schedule)
+
+        const dependencies = {
+            executeScheduledServers: mock<ExecuteScheduledServers>(),
+            eventLogger: mock<EventLogger>(),
+        }
+
+        return {
+            sut: scheduleScheduledServerCreationRoutine,
+            scheduleMock,
+            dependencies,
+        }
+    }
+
+    describe("Scheduling", () => {
+
+        it("should schedule the job to run every minute", () => {
+            // Given
+            const { sut, scheduleMock, dependencies } = makeSut();
+
+            // When
+            sut(dependencies);
+
+            // Then
+            expect(scheduleMock.scheduleJob).toHaveBeenCalledWith("* * * * *", expect.any(Function));
+        })
+
+    })
+
+    describe("Job Execution", () => {
+        // Given
+        const { sut, dependencies, scheduleMock } = makeSut();
+
+        sut(dependencies);
+
+        const scheduledJobCallback = scheduleMock.scheduleJob.mock.calls[0][1];
+        scheduledJobCallback(new Date());
+
+        it("should call executeScheduledServers.execute", () => {
+            expect(dependencies.executeScheduledServers.execute).toHaveBeenCalled();
+        })
+    })
+})

--- a/packages/entrypoints/src/jobs/ScheduledServerCreationRoutine.ts
+++ b/packages/entrypoints/src/jobs/ScheduledServerCreationRoutine.ts
@@ -1,0 +1,14 @@
+import { ExecuteScheduledServers } from '@tf2qs/core';
+import { EventLogger } from '@tf2qs/core';
+import { createScheduledRoutine } from './createScheduledRoutine';
+
+// Schedule a job to run every minute
+export const scheduleScheduledServerCreationRoutine = (dependencies: {
+    executeScheduledServers: ExecuteScheduledServers,
+    eventLogger: EventLogger
+}) => {
+    createScheduledRoutine('* * * * *', 'Scheduled Server Creation Routine', () =>
+        dependencies.executeScheduledServers.execute(),
+        dependencies.eventLogger
+    );
+};

--- a/packages/entrypoints/src/jobs/index.ts
+++ b/packages/entrypoints/src/jobs/index.ts
@@ -2,4 +2,5 @@ export * from "./ServerCleanupRoutine"
 export * from "./PendingServerCleanupRoutine";
 export * from "./TerminateLongRunningServerRoutine";
 export * from "./MonthlyUsageReportRoutine";
+export * from "./ScheduledServerCreationRoutine";
 export * from "./createScheduledRoutine";

--- a/packages/providers/src/queue/CreateScheduledServerTaskProcessor.test.ts
+++ b/packages/providers/src/queue/CreateScheduledServerTaskProcessor.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest';
+import { mock } from 'vitest-mock-extended';
+import { when } from 'vitest-when';
+import { ExecuteScheduledServerCreation } from '@tf2qs/core';
+import { createScheduledServerTaskProcessor } from './CreateScheduledServerTaskProcessor';
+import { GenericTaskProcessor } from './GenericTaskProcessor';
+
+describe('createScheduledServerTaskProcessor', () => {
+  const makeSut = () => {
+    const executeScheduledServerCreation = mock<ExecuteScheduledServerCreation>();
+    const sut = createScheduledServerTaskProcessor(executeScheduledServerCreation);
+    return { executeScheduledServerCreation, sut };
+  };
+
+  it('should create a GenericTaskProcessor with correct dependencies', () => {
+    const { sut } = makeSut();
+
+    expect(sut).toBeInstanceOf(GenericTaskProcessor);
+  });
+
+  it('should process a create scheduled server task successfully', async () => {
+    const { executeScheduledServerCreation, sut } = makeSut();
+    const scheduleId = 'test-schedule-id';
+
+    when(executeScheduledServerCreation.execute).calledWith({ scheduleId }).thenResolve(undefined);
+
+    await sut.process({ scheduleId });
+
+    expect(executeScheduledServerCreation.execute).toHaveBeenCalledWith({ scheduleId });
+  });
+
+  it('should throw when the create scheduled server use case fails', async () => {
+    const { executeScheduledServerCreation, sut } = makeSut();
+    const scheduleId = 'test-schedule-id';
+    const error = new Error('Creation failed');
+
+    when(executeScheduledServerCreation.execute).calledWith({ scheduleId }).thenReject(error);
+
+    await expect(sut.process({ scheduleId })).rejects.toThrow('Creation failed');
+  });
+});

--- a/packages/providers/src/queue/CreateScheduledServerTaskProcessor.ts
+++ b/packages/providers/src/queue/CreateScheduledServerTaskProcessor.ts
@@ -1,0 +1,15 @@
+import { GenericTaskProcessor } from './GenericTaskProcessor';
+import { ExecuteScheduledServerCreation } from '@tf2qs/core';
+
+export type CreateScheduledServerTaskData = {
+  scheduleId: string;
+};
+
+export function createScheduledServerTaskProcessor(
+  executeScheduledServerCreation: ExecuteScheduledServerCreation
+): GenericTaskProcessor<CreateScheduledServerTaskData> {
+  return new GenericTaskProcessor({
+    useCase: executeScheduledServerCreation,
+    taskName: 'create-scheduled-server',
+  });
+}

--- a/packages/providers/src/queue/InMemoryBackgroundTaskQueue.test.ts
+++ b/packages/providers/src/queue/InMemoryBackgroundTaskQueue.test.ts
@@ -95,7 +95,7 @@ describe('InMemoryBackgroundTaskQueue', () => {
       expect(processor.process).toHaveBeenCalled();
     });
 
-    it('should process multiple tasks in order', async () => {
+    it('should process all ready tasks concurrently', async () => {
       const processor = mock<BackgroundTaskProcessor>();
       processor.process.mockResolvedValue(undefined);
       
@@ -330,7 +330,7 @@ describe('InMemoryBackgroundTaskQueue', () => {
       expect(onSuccess).toHaveBeenCalledWith({ success: true });
     });
 
-    it('should process retried tasks in order with other tasks', async () => {
+    it('should process retried tasks concurrently with other tasks', async () => {
       const processor = mock<BackgroundTaskProcessor>();
       const results: string[] = [];
 
@@ -351,9 +351,13 @@ describe('InMemoryBackgroundTaskQueue', () => {
 
       await sut.start();
 
-      await vi.advanceTimersByTimeAsync(3500);
-      expect(results).toEqual(['2', '3']);
+      // Concurrent contract: all ready tasks are processed within the first tick.
+      // '2' and '3' complete immediately; '1' fails and is retried after the 1s backoff.
+      await vi.advanceTimersByTimeAsync(1100);
+      expect(results).toEqual(expect.arrayContaining(['2', '3']));
+      expect(results).not.toContain('1');
 
+      // After advancing past the retry backoff, '1' is re-processed
       await vi.advanceTimersByTimeAsync(1500);
       expect(results).toEqual(['2', '3', '1']);
 

--- a/packages/providers/src/queue/InMemoryBackgroundTaskQueue.ts
+++ b/packages/providers/src/queue/InMemoryBackgroundTaskQueue.ts
@@ -128,17 +128,25 @@ export class InMemoryBackgroundTaskQueue implements BackgroundTaskQueue {
     }
 
     const now = new Date();
-    const readyTaskIndex = this.tasks.findIndex((task) => !task.scheduledAt || task.scheduledAt <= now);
+    const readyTasks = this.tasks.filter((task) => !task.scheduledAt || task.scheduledAt <= now);
 
-    if (readyTaskIndex === -1) {
+    if (readyTasks.length === 0) {
       return;
     }
 
-    const task = this.tasks.splice(readyTaskIndex, 1)[0];
-    if (!task) {
-      return;
-    }
+    this.tasks = this.tasks.filter((task) => !readyTasks.includes(task));
 
+    // Overlap safety: ready tasks are removed from this.tasks before processing, and
+    // retries are re-pushed with a future scheduledAt, so two overlapping processTasks
+    // invocations (e.g. if a batch outlives the 1s tick) can never double-process a task.
+
+    // Process all ready tasks concurrently. allSettled keeps one failing task's
+    // internal handling (already try/caught in processTask) from rejecting the
+    // whole batch; it is the safe choice even though processTask never rejects.
+    await Promise.allSettled(readyTasks.map((task) => this.processTask(task)));
+  }
+
+  private async processTask(task: BackgroundTask): Promise<void> {
     const processor = this.processors.get(task.type);
     if (!processor) {
       logger.emit({

--- a/packages/providers/src/queue/index.ts
+++ b/packages/providers/src/queue/index.ts
@@ -1,4 +1,5 @@
 export * from './CreateServerForClientTaskProcessor';
+export * from './CreateScheduledServerTaskProcessor';
 export * from './DeleteServerForUserTaskProcessor';
 export * from './DeleteServerTaskProcessor';
 export * from './GenericTaskProcessor';

--- a/packages/providers/src/repository/SQLiteScheduledServerRepository.test.ts
+++ b/packages/providers/src/repository/SQLiteScheduledServerRepository.test.ts
@@ -1,0 +1,277 @@
+import { Knex, knex as createKnex } from "knex";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { Region } from "@tf2qs/core";
+import { ScheduledServer } from "@tf2qs/core";
+import { SQLiteScheduledServerRepository } from "./SQLiteScheduledServerRepository";
+
+function createSchedule(overrides: Partial<ScheduledServer> = {}): ScheduledServer {
+    return {
+        id: "schedule-1",
+        userId: "user-1",
+        guildId: null,
+        region: "sa-saopaulo-1" as Region,
+        variant: "standard-competitive" as const,
+        scheduledAt: new Date("2026-08-01T21:30:00Z"),
+        triggerAt: new Date("2026-08-01T21:25:00Z"),
+        status: "scheduled",
+        serverId: null,
+        timezone: "UTC",
+        createdAt: new Date("2026-08-01T10:00:00Z"),
+        updatedAt: new Date("2026-08-01T10:00:00Z"),
+        ...overrides,
+    };
+}
+
+describe("SQLiteScheduledServerRepository", () => {
+    let knex: Knex;
+    let sut: SQLiteScheduledServerRepository;
+
+    beforeEach(async () => {
+        knex = createKnex({
+            client: "sqlite3",
+            connection: { filename: ":memory:" },
+            useNullAsDefault: true,
+            pool: { min: 0, max: 1 },
+        });
+        await knex.schema.createTable("scheduled_servers", (table) => {
+            table.string("id").primary();
+            table.string("userId").notNullable();
+            table.string("guildId").nullable();
+            table.string("region").notNullable();
+            table.string("variant").notNullable();
+            table.timestamp("scheduledAt").notNullable();
+            table.timestamp("triggerAt").notNullable();
+            table.string("status").notNullable().defaultTo("scheduled");
+            table.check("status IN ('scheduled','creating','created','failed','cancelled')");
+            table.string("serverId").nullable();
+            table.string("timezone").notNullable();
+            table.timestamp("createdAt").notNullable();
+            table.timestamp("updatedAt").notNullable();
+            table.index(["userId"]);
+            table.index(["status"]);
+            table.index(["status", "triggerAt"]);
+        });
+        sut = new SQLiteScheduledServerRepository({ knex });
+    });
+
+    afterEach(async () => {
+        await knex.destroy();
+    });
+
+    it("should create and read back a schedule with deserialized dates", async () => {
+        // Given
+        const schedule = createSchedule();
+
+        // When
+        await sut.create(schedule);
+
+        // Then
+        const found = await sut.findActiveByUserId("user-1");
+        expect(found).toHaveLength(1);
+        expect(found[0]).toEqual(schedule);
+        expect(found[0].scheduledAt).toBeInstanceOf(Date);
+        expect(found[0].triggerAt.getTime()).toBe(new Date("2026-08-01T21:25:00Z").getTime());
+    });
+
+    it("should find a schedule by id with deserialized dates", async () => {
+        // Given
+        const schedule = createSchedule({ guildId: "guild-1", serverId: "server-9" });
+        await sut.create(schedule);
+
+        // When
+        const found = await sut.findById(schedule.id);
+
+        // Then
+        expect(found).toEqual(schedule);
+        expect(found?.scheduledAt).toBeInstanceOf(Date);
+        expect(found?.triggerAt.getTime()).toBe(new Date("2026-08-01T21:25:00Z").getTime());
+    });
+
+    it("should return null when no schedule matches the id", async () => {
+        // When
+        const found = await sut.findById("nonexistent");
+
+        // Then
+        expect(found).toBeNull();
+    });
+
+    it("should store null guildId and serverId as null", async () => {        // Given
+        const schedule = createSchedule({ guildId: null, serverId: null });
+
+        // When
+        await sut.create(schedule);
+
+        // Then
+        const row = await knex("scheduled_servers").where({ id: schedule.id }).first();
+        expect(row.guildId).toBeNull();
+        expect(row.serverId).toBeNull();
+    });
+
+    it("should persist guildId and serverId when present", async () => {
+        // Given
+        const schedule = createSchedule({ guildId: "guild-1", serverId: "server-9" });
+
+        // When
+        await sut.create(schedule);
+
+        // Then
+        const row = await knex("scheduled_servers").where({ id: schedule.id }).first();
+        expect(row.guildId).toBe("guild-1");
+        expect(row.serverId).toBe("server-9");
+    });
+
+    it("should only find active (scheduled/creating) schedules for a user", async () => {
+        // Given
+        await sut.create(createSchedule({ id: "a1", userId: "user-1", status: "scheduled" }));
+        await sut.create(createSchedule({ id: "a2", userId: "user-1", status: "creating" }));
+        await sut.create(createSchedule({ id: "a3", userId: "user-1", status: "cancelled" }));
+        await sut.create(createSchedule({ id: "a4", userId: "user-1", status: "created" }));
+        await sut.create(createSchedule({ id: "a5", userId: "user-2", status: "scheduled" }));
+
+        // When
+        const found = await sut.findActiveByUserId("user-1");
+
+        // Then
+        expect(found.map(s => s.id)).toEqual(["a1", "a2"]);
+    });
+
+    it("should order active schedules by scheduledAt ascending", async () => {
+        // Given
+        await sut.create(createSchedule({ id: "later", scheduledAt: new Date("2026-08-03T21:30:00Z") }));
+        await sut.create(createSchedule({ id: "earlier", scheduledAt: new Date("2026-08-01T21:30:00Z") }));
+
+        // When
+        const found = await sut.findActiveByUserId("user-1");
+
+        // Then
+        expect(found.map(s => s.id)).toEqual(["earlier", "later"]);
+    });
+
+    it("should find due schedules whose triggerAt is at or before now", async () => {
+        // Given
+        const now = new Date("2026-08-01T21:26:00Z");
+        await sut.create(createSchedule({ id: "due", triggerAt: new Date("2026-08-01T21:25:00Z") }));
+        await sut.create(createSchedule({ id: "boundary", triggerAt: now }));
+        await sut.create(createSchedule({ id: "future", triggerAt: new Date("2026-08-01T21:27:00Z") }));
+        await sut.create(createSchedule({ id: "not-scheduled", status: "creating", triggerAt: new Date("2026-08-01T21:25:00Z") }));
+
+        // When
+        const found = await sut.findDue(now);
+
+        // Then
+        expect(found.map(s => s.id)).toEqual(["due", "boundary"]);
+    });
+
+    it("should find stuck creating schedules updated at or before the given time", async () => {
+        // Given
+        const before = new Date("2026-08-01T10:21:00Z");
+        await sut.create(createSchedule({ id: "stuck", status: "creating", updatedAt: new Date("2026-08-01T10:00:00Z") }));
+        await sut.create(createSchedule({ id: "boundary", status: "creating", updatedAt: before }));
+        await sut.create(createSchedule({ id: "fresh", status: "creating", updatedAt: new Date("2026-08-01T10:22:00Z") }));
+        await sut.create(createSchedule({ id: "scheduled-not-stuck", status: "scheduled", updatedAt: new Date("2026-08-01T10:00:00Z") }));
+
+        // When
+        const found = await sut.findStuckCreating(before);
+
+        // Then
+        expect(found.map(s => s.id)).toEqual(["stuck", "boundary"]);
+    });
+
+    it("should claim a scheduled schedule and return true", async () => {
+        // Given
+        const schedule = createSchedule();
+        await sut.create(schedule);
+        const now = new Date("2026-08-01T21:26:00Z");
+
+        // When
+        const claimed = await sut.claimForProcessing(schedule.id, now);
+
+        // Then
+        expect(claimed).toBe(true);
+        const row = await knex("scheduled_servers").where({ id: schedule.id }).first();
+        expect(row.status).toBe("creating");
+        expect(new Date(row.updatedAt).getTime()).toBe(now.getTime());
+    });
+
+    it("should not claim a schedule that is not in scheduled status", async () => {
+        // Given
+        const schedule = createSchedule({ status: "creating", serverId: "server-1" });
+        await sut.create(schedule);
+
+        // When
+        const claimed = await sut.claimForProcessing(schedule.id, new Date());
+
+        // Then
+        expect(claimed).toBe(false);
+        const row = await knex("scheduled_servers").where({ id: schedule.id }).first();
+        expect(row.status).toBe("creating");
+    });
+
+    it("should mark the status and optionally the server id", async () => {
+        // Given
+        const schedule = createSchedule();
+        await sut.create(schedule);
+        const now = new Date("2026-08-01T21:50:00Z");
+
+        // When
+        await sut.markStatus(schedule.id, "created", "server-1", now);
+
+        // Then
+        const row = await knex("scheduled_servers").where({ id: schedule.id }).first();
+        expect(row.status).toBe("created");
+        expect(row.serverId).toBe("server-1");
+        expect(new Date(row.updatedAt).getTime()).toBe(now.getTime());
+    });
+
+    it("should clear the server id when marking without one", async () => {
+        // Given
+        const schedule = createSchedule({ serverId: "server-1" });
+        await sut.create(schedule);
+
+        // When
+        await sut.markStatus(schedule.id, "failed", undefined, new Date());
+
+        // Then
+        const row = await knex("scheduled_servers").where({ id: schedule.id }).first();
+        expect(row.status).toBe("failed");
+        expect(row.serverId).toBeNull();
+    });
+
+    it("should cancel a scheduled schedule and return true", async () => {
+        // Given
+        const schedule = createSchedule();
+        await sut.create(schedule);
+        const now = new Date("2026-08-01T12:00:00Z");
+
+        // When
+        const cancelled = await sut.cancel(schedule.id, now);
+
+        // Then
+        expect(cancelled).toBe(true);
+        const row = await knex("scheduled_servers").where({ id: schedule.id }).first();
+        expect(row.status).toBe("cancelled");
+        expect(new Date(row.updatedAt).getTime()).toBe(now.getTime());
+    });
+
+    it("should not cancel a schedule that is not in scheduled status", async () => {
+        // Given
+        const schedule = createSchedule({ status: "creating", serverId: "server-1" });
+        await sut.create(schedule);
+
+        // When
+        const cancelled = await sut.cancel(schedule.id, new Date());
+
+        // Then
+        expect(cancelled).toBe(false);
+        const row = await knex("scheduled_servers").where({ id: schedule.id }).first();
+        expect(row.status).toBe("creating");
+    });
+
+    it("should return an empty list for a user with no active schedules", async () => {
+        // When
+        const found = await sut.findActiveByUserId("ghost");
+
+        // Then
+        expect(found).toEqual([]);
+    });
+});

--- a/packages/providers/src/repository/SQLiteScheduledServerRepository.ts
+++ b/packages/providers/src/repository/SQLiteScheduledServerRepository.ts
@@ -1,0 +1,120 @@
+import { Knex } from "knex";
+import { Region, ScheduledServer, ScheduledServerRepository, ScheduledServerStatus, Variant } from "@tf2qs/core";
+
+// DB row shape as stored by create(): dates are ISO strings, nullable fields are null
+type ScheduledServerRow = {
+    id: string;
+    userId: string;
+    guildId: string | null;
+    region: Region;
+    variant: Variant;
+    scheduledAt: string;
+    triggerAt: string;
+    status: ScheduledServerStatus;
+    serverId: string | null;
+    timezone: string;
+    createdAt: string;
+    updatedAt: string;
+};
+
+export class SQLiteScheduledServerRepository implements ScheduledServerRepository {
+
+    constructor(private readonly dependencies: { knex: Knex }) {}
+
+    async create(schedule: ScheduledServer): Promise<void> {
+        await this.dependencies.knex('scheduled_servers')
+            .insert({
+                id: schedule.id,
+                userId: schedule.userId,
+                guildId: schedule.guildId ?? null,
+                region: schedule.region,
+                variant: schedule.variant,
+                scheduledAt: schedule.scheduledAt.toISOString(),
+                triggerAt: schedule.triggerAt.toISOString(),
+                status: schedule.status,
+                serverId: schedule.serverId ?? null,
+                timezone: schedule.timezone,
+                createdAt: schedule.createdAt.toISOString(),
+                updatedAt: schedule.updatedAt.toISOString()
+            });
+    }
+
+    async findById(id: string): Promise<ScheduledServer | null> {
+        const row = await this.dependencies.knex('scheduled_servers')
+            .where({ id })
+            .first();
+        return row ? this.deserialize(row) : null;
+    }
+
+    async findActiveByUserId(userId: string): Promise<ScheduledServer[]> {
+        const rows = await this.dependencies.knex('scheduled_servers')
+            .where({ userId })
+            .whereIn('status', ['scheduled', 'creating'])
+            .orderBy('scheduledAt', 'asc')
+            .select('*');
+        return rows.map(this.deserialize);
+    }
+
+    async findDue(now: Date): Promise<ScheduledServer[]> {
+        const rows = await this.dependencies.knex('scheduled_servers')
+            .where({ status: 'scheduled' })
+            .andWhere('triggerAt', '<=', now.toISOString())
+            .select('*');
+        return rows.map(this.deserialize);
+    }
+
+    async findStuckCreating(before: Date): Promise<ScheduledServer[]> {
+        const rows = await this.dependencies.knex('scheduled_servers')
+            .where({ status: 'creating' })
+            .andWhere('updatedAt', '<=', before.toISOString())
+            .select('*');
+        return rows.map(this.deserialize);
+    }
+
+    async claimForProcessing(id: string, now: Date): Promise<boolean> {
+        const result = await this.dependencies.knex('scheduled_servers')
+            .where({ id })
+            .where({ status: 'scheduled' })
+            .update({
+                status: 'creating',
+                updatedAt: now.toISOString()
+            });
+        return result === 1;
+    }
+
+    async markStatus(id: string, status: ScheduledServerStatus, serverId?: string, now?: Date): Promise<void> {
+        const updatedAt = (now ?? new Date()).toISOString();
+        await this.dependencies.knex('scheduled_servers')
+            .where({ id })
+            .update({
+                status,
+                serverId: serverId ?? null,
+                updatedAt
+            });
+    }
+
+    async cancel(id: string, now: Date): Promise<boolean> {
+        const result = await this.dependencies.knex('scheduled_servers')
+            .where({ id })
+            .where({ status: 'scheduled' })
+            .update({
+                status: 'cancelled',
+                updatedAt: now.toISOString()
+            });
+        return result === 1;
+    }
+
+    private deserialize(row: ScheduledServerRow): ScheduledServer {
+        return {
+            ...row,
+            scheduledAt: toDate(row.scheduledAt),
+            triggerAt: toDate(row.triggerAt),
+            createdAt: toDate(row.createdAt),
+            updatedAt: toDate(row.updatedAt)
+        };
+    }
+}
+
+function toDate(value: string): Date {
+    return new Date(value);
+}

--- a/packages/providers/src/repository/index.ts
+++ b/packages/providers/src/repository/index.ts
@@ -7,3 +7,4 @@ export * from './SQLiteServerRepository';
 export * from './SQLiteUserRepository';
 export * from './SQLiteServerStatusMetricsRepository';
 export * from './SQLitePlayerConnectionHistoryRepository';
+export * from './SQLiteScheduledServerRepository';


### PR DESCRIPTION
## Summary

Adds scheduled server creation: users can schedule a server to be created and ready at a specific time in a specific region, then receive DMs with connection info when it's ready.

### New Discord commands
- **`/schedule`** — region, ready time (HH:mm, 24h), and timezone; shows a variant-selection button row after validating the time. Confirmation DM is sent before persisting the schedule (DM-ability is verified up front so connection info can always be delivered).
- **`/show-schedules`** — lists the user's active schedules with status, local + UTC ready times, and relative countdown.
- **`/cancel-schedule`** — cancels the user's active schedule (not allowed once creation has started).

### Domain / use cases (`packages/core`)
- `ScheduledServer` domain model + `ScheduledServerRepository` contract.
- `CreateScheduledServer` — validates time/timezone, computes `scheduledAt` (next occurrence, DST-aware) and `triggerAt` (scheduledAt − lead minutes), enforces one active schedule per user, sends confirmation DM before persisting.
- `GetUserSchedules` / `CancelScheduledServer`.
- `ExecuteScheduledServers` — per-minute routine entry point: recovers schedules stuck in `creating` (>20 min) and enqueues due schedules as background tasks (with a 30-min offline grace period).
- `ExecuteScheduledServerCreation` — background task that creates the server via the shared `CreateServerForUser` and DMs the connection info; marks schedules `created`/`failed`.
- `scheduleTime` utils — next-occurrence computation with deterministic DST handling, timezone-aware formatting, duration formatting.
- `failSafeDirectMessage` util — DM delivery that logs a WARN instead of aborting the caller's flow.

### Persistence (`packages/providers`)
- `scheduled_servers` migration (with `status` check constraint and indexes on userId / status / triggerAt).
- `SQLiteScheduledServerRepository` — atomic claim (`scheduled`→`creating`), cancel, status updates, due/stuck queries.

### Wiring (`packages/entrypoints`)
- `discordBot.ts` wires the repository, use cases, and the `create-scheduled-server` task processor; `ScheduledServerCreationRoutine` runs every minute.
- Config lead times: `scheduledCreationLeadMinutes` per region (5 min for Oracle regions, 12 min for the experimental AWS regions).

### Background task queue
- `InMemoryBackgroundTaskQueue` now processes all ready tasks concurrently per tick instead of one-at-a-time in order (overlap-safe: ready tasks are removed before processing, retries re-push with future `scheduledAt`).

## Testing
- New unit tests for every use case, util, command handler, task processor, the repository (in-memory SQLite), and the routine.
- Updated `InMemoryBackgroundTaskQueue` tests for the concurrency contract; `discordBot.test.ts` covers the scheduled-server wiring.
- Full suite passes: **79 test files, 519 tests**. `tsc` build passes.

## Notes
- No PR template found in the repo; structured per project conventions.
- No secrets in the diff; `rconPassword`/token references are test fixtures and existing code.
