### PR TITLE
Added servercfgfile execution on default cfg

### DIFF
--- a/variants/base/tf/cfg/fbtf_6v6_5cp.cfg
+++ b/variants/base/tf/cfg/fbtf_6v6_5cp.cfg
@@ -1,6 +1,8 @@
 // FBTF PUSH 6v6 CFG
 exec fbtf_6v6
 
+servercfgfile "fbtf_6v6_5cp"
+
 mp_timelimit			"30"
 mp_winlimit 			"5"
 mp_roundtime "240"	


### PR DESCRIPTION
Quando é criado um servidor pelo bot escolhendo a opção "Standard Competitive" a cfg padrão carregada é a"fbtf_6v6_5cp":

<img width="520" height="179" alt="image" src="https://github.com/user-attachments/assets/d2987161-cac0-4b19-b546-66a92ec73953" />

Estamos com uma situação na Brasil Fortress em que usuários usando essa opção esquecem de trocar a cfg em mudança de mapas. O Chat informa para ele após a mudança do mapa que a CFG ainda é a da BF:

<img width="453" height="202" alt="image" src="https://github.com/user-attachments/assets/348afde2-4e0f-4709-91c0-af8e38efc482" />

No caso validamos que na cfg padrão, que vai executar a cada mudança de mapa, não está atualizando essa cvar com o valor correto resultando em confusão de algumas equipes que sobem o servidor nesse modelo que acham que a cfg ainda é a da BF.

Essa mudança vai alterar o comportamento e mostrar a cfg correta sempre. Atualmente quando abre o servidor está mostrando também a cfg incorreta:
<img width="566" height="205" alt="image" src="https://github.com/user-attachments/assets/06ace52a-376f-473c-8bf6-7e924ac81577" />

Ficando então assim:
<img width="872" height="410" alt="image" src="https://github.com/user-attachments/assets/3533c4f3-6e03-4c58-ac76-a922abb6a9bf" />


Vale notar que não modifiquei nenhuma outra cfg padrão, nem validei se nas outras está faltando configurar isso. Seria legal passar por todas e arrumar se necessário.