### PR TITLE
feat(api): add SourceTV connections endpoint with scope-based auth

### DIFF
--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -22,7 +22,9 @@ components:
       flows:
         clientCredentials:
           tokenUrl: https://tf2-quickserver.us.auth0.com/oauth/token
-          scopes: {}
+          scopes:
+            manage:servers: Manage TF2 servers (list, create, delete, and task status)
+            read:sourcetv:all: Read SourceTV connection info for all servers
   schemas:
     Server:
       type: object
@@ -72,6 +74,29 @@ components:
             - pending
             - ready
             - terminating
+    SourceTvInfo:
+      type: object
+      description: SourceTV connection information for a ready server. RCON and join passwords are never included.
+      properties:
+        serverId:
+          type: string
+          example: a1b2c3d4-e5f6-7890-abcd-ef1234567890
+        hostIp:
+          type: string
+          example: 1.2.3.4
+        hostPort:
+          type: integer
+          example: 27015
+        tvIp:
+          type: string
+          example: 1.2.3.4
+        tvPort:
+          type: integer
+          example: 27020
+        tvPassword:
+          type: string
+          example: tvpass123
+          description: SourceTV password (omitted when not set)
     CreateServerRequest:
       type: object
       required:
@@ -184,10 +209,13 @@ paths:
         Enqueues a server creation task and returns a task ID immediately.
         Server creation typically takes 4-6 minutes. Poll `GET /api/tasks/{taskId}` to check status.
         When completed, the task result contains the full server details including credentials.
+        Requires the `manage:servers` scope.
       tags:
         - Servers
       security:
         - bearerAuth: []
+        - oauth2:
+            - manage:servers
       requestBody:
         required: true
         content:
@@ -207,11 +235,13 @@ paths:
           $ref: '#/components/responses/Unauthorized'
     get:
       summary: List all servers for the authenticated client
-      description: Returns all TF2 game servers associated with the authenticated API client.
+      description: Returns all TF2 game servers associated with the authenticated API client. Requires the `manage:servers` scope.
       tags:
         - Servers
       security:
         - bearerAuth: []
+        - oauth2:
+            - manage:servers
       responses:
         '200':
           description: A list of servers
@@ -230,10 +260,13 @@ paths:
         Enqueues a server deletion task and returns a task ID immediately.
         Server deletion typically takes 1-3 minutes. Poll `GET /api/tasks/{taskId}` to check status.
         Only the client that created the server may delete it.
+        Requires the `manage:servers` scope.
       tags:
         - Servers
       security:
         - bearerAuth: []
+        - oauth2:
+            - manage:servers
       parameters:
         - in: path
           name: serverId
@@ -262,10 +295,13 @@ paths:
         (e.g. server creation or deletion). When `status` is `completed`, the `result`
         field contains the full server object. When `status` is `failed`, the `error`
         field contains the failure reason.
+        Requires the `manage:servers` scope.
       tags:
         - Tasks
       security:
         - bearerAuth: []
+        - oauth2:
+            - manage:servers
       parameters:
         - in: path
           name: taskId
@@ -286,4 +322,29 @@ paths:
           $ref: '#/components/responses/Forbidden'
         '404':
           $ref: '#/components/responses/NotFound'
+  /api/sourcetv-connections:
+    get:
+      summary: List SourceTV information for all servers
+      description: |
+        Returns SourceTV connection information for all ready TF2 game servers across QuickServer.
+        Requires the `read:sourcetv:all` scope. RCON and server join passwords are never exposed.
+      tags:
+        - SourceTV
+      security:
+        - bearerAuth: []
+        - oauth2:
+            - read:sourcetv:all
+      responses:
+        '200':
+          description: A list of SourceTV information for all ready servers
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/SourceTvInfo'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
 tags: []

--- a/docs/oauth.md
+++ b/docs/oauth.md
@@ -75,12 +75,19 @@ In the Auth0 Dashboard:
 In the **Permissions** tab, add the following scopes:
 
 ```
-read:servers         - Allows reading data from all servers
-create:servers       - Allow creating servers
-read:servers:own     - Allows only reading data from the servers created by the client
-delete:servers:own   - Allows deleting your own created servers
-delete:servers       - Allows deleting all servers
+manage:servers       - Allows managing TF2 servers (list, create, delete, and task status)
+read:sourcetv:all    - Allows reading SourceTV connection info (IP, port, TV password) for all servers via GET /api/sourcetv-connections
 ```
+
+> **Scope requirements by endpoint:**
+>
+> - `GET /api/servers`, `POST /api/servers`, `DELETE /api/servers/{serverId}`, and `GET /api/tasks/{taskId}` require `manage:servers`.
+> - `GET /api/sourcetv-connections` requires `read:sourcetv:all`.
+> - `GET /api/profile` is available to any authenticated client and returns the scopes granted to it.
+>
+> **Note:** `read:sourcetv:all` is intended for monitoring partners. It only exposes SourceTV
+> connection data (server IP/port, TV address, and TV password); RCON and join passwords are
+> never returned.
 
 ### 4. Create Machine-to-Machine Application
 

--- a/packages/core/index.ts
+++ b/packages/core/index.ts
@@ -46,6 +46,7 @@ export * from './src/usecase/ExecuteScheduledServerCreation';
 export * from './src/usecase/ExecuteScheduledServers';
 export * from './src/usecase/GenerateMonthlyUsageReport';
 export * from './src/usecase/GetServerStatus';
+export * from './src/usecase/GetSourceTvInfo';
 export * from './src/usecase/GetGuildServers';
 export * from './src/usecase/GetUserServers';
 export * from './src/usecase/GetUserSchedules';

--- a/packages/core/src/usecase/GetSourceTvInfo.test.ts
+++ b/packages/core/src/usecase/GetSourceTvInfo.test.ts
@@ -1,0 +1,138 @@
+import { describe, expect, it } from "vitest";
+import { mock } from "vitest-mock-extended";
+import { when } from "vitest-when";
+import { Server, Region } from "../domain";
+import { ServerRepository } from "../repository/ServerRepository";
+import { GetSourceTvInfo, SourceTvInfo } from "./GetSourceTvInfo";
+import Chance from "chance";
+
+const chance = new Chance();
+
+describe("GetSourceTvInfo", () => {
+    const makeSut = () => {
+        const serverRepository = mock<ServerRepository>();
+        const sut = new GetSourceTvInfo({ serverRepository });
+        return { sut, serverRepository };
+    };
+
+    const makeServer = (overrides: Partial<Server> = {}): Server => ({
+        serverId: chance.guid(),
+        region: Region.US_CHICAGO_1,
+        variant: "standard-competitive",
+        hostIp: chance.ip(),
+        hostPort: 27015,
+        tvIp: chance.ip(),
+        tvPort: 27020,
+        rconPassword: chance.word(),
+        rconAddress: `${chance.ip()}:27015`,
+        hostPassword: chance.word(),
+        tvPassword: chance.word(),
+        status: "ready",
+        ...overrides,
+    });
+
+    it("should return SourceTV info for all ready servers", async () => {
+        // Given
+        const { sut, serverRepository } = makeSut();
+        const readyServer = makeServer();
+        const anotherReadyServer = makeServer();
+        when(serverRepository.getAllServers)
+            .calledWith()
+            .thenResolve([readyServer, anotherReadyServer]);
+
+        // When
+        const result = await sut.execute();
+
+        // Then
+        const expected: SourceTvInfo[] = [
+            {
+                serverId: readyServer.serverId,
+                hostIp: readyServer.hostIp,
+                hostPort: readyServer.hostPort,
+                tvIp: readyServer.tvIp,
+                tvPort: readyServer.tvPort,
+                tvPassword: readyServer.tvPassword,
+            },
+            {
+                serverId: anotherReadyServer.serverId,
+                hostIp: anotherReadyServer.hostIp,
+                hostPort: anotherReadyServer.hostPort,
+                tvIp: anotherReadyServer.tvIp,
+                tvPort: anotherReadyServer.tvPort,
+                tvPassword: anotherReadyServer.tvPassword,
+            },
+        ];
+        expect(result).toEqual(expected);
+        expect(serverRepository.getAllServers).toHaveBeenCalledWith();
+    });
+
+    it("should exclude servers that are not ready", async () => {
+        // Given
+        const { sut, serverRepository } = makeSut();
+        const readyServer = makeServer();
+        const pendingServer = makeServer({ status: "pending" });
+        const terminatingServer = makeServer({ status: "terminating" });
+        when(serverRepository.getAllServers)
+            .calledWith()
+            .thenResolve([readyServer, pendingServer, terminatingServer]);
+
+        // When
+        const result = await sut.execute();
+
+        // Then
+        expect(result).toHaveLength(1);
+        expect(result[0].serverId).toBe(readyServer.serverId);
+    });
+
+    it("should not expose rcon or host passwords", async () => {
+        // Given
+        const { sut, serverRepository } = makeSut();
+        const readyServer = makeServer();
+        when(serverRepository.getAllServers)
+            .calledWith()
+            .thenResolve([readyServer]);
+
+        // When
+        const result = await sut.execute();
+
+        // Then
+        expect(result[0]).not.toHaveProperty("rconPassword");
+        expect(result[0]).not.toHaveProperty("hostPassword");
+        expect(result[0]).not.toHaveProperty("rconAddress");
+    });
+
+    it("should omit tvPassword when the server has no SourceTV password", async () => {
+        // Given
+        const { sut, serverRepository } = makeSut();
+        const readyServer = makeServer({ tvPassword: undefined });
+        when(serverRepository.getAllServers)
+            .calledWith()
+            .thenResolve([readyServer]);
+
+        // When
+        const result = await sut.execute();
+
+        // Then
+        expect(result[0]).toEqual({
+            serverId: readyServer.serverId,
+            hostIp: readyServer.hostIp,
+            hostPort: readyServer.hostPort,
+            tvIp: readyServer.tvIp,
+            tvPort: readyServer.tvPort,
+        });
+    });
+
+    it("should return an empty array when there are no ready servers", async () => {
+        // Given
+        const { sut, serverRepository } = makeSut();
+        when(serverRepository.getAllServers)
+            .calledWith()
+            .thenResolve([]);
+
+        // When
+        const result = await sut.execute();
+
+        // Then
+        expect(result).toEqual([]);
+    });
+});

--- a/packages/core/src/usecase/GetSourceTvInfo.ts
+++ b/packages/core/src/usecase/GetSourceTvInfo.ts
@@ -1,0 +1,33 @@
+import { ServerRepository } from "../repository/ServerRepository";
+
+export type SourceTvInfo = {
+    serverId: string;
+    hostIp: string;
+    hostPort: number;
+    tvIp: string;
+    tvPort: number;
+    tvPassword?: string;
+};
+
+export class GetSourceTvInfo {
+    constructor(private readonly dependencies: {
+        serverRepository: ServerRepository;
+    }) { }
+
+    async execute(): Promise<SourceTvInfo[]> {
+        const { serverRepository } = this.dependencies;
+
+        const servers = await serverRepository.getAllServers();
+
+        return servers
+            .filter(server => server.status === "ready")
+            .map(server => ({
+                serverId: server.serverId,
+                hostIp: server.hostIp,
+                hostPort: server.hostPort,
+                tvIp: server.tvIp,
+                tvPort: server.tvPort,
+                tvPassword: server.tvPassword,
+            }));
+    }
+}

--- a/packages/entrypoints/src/discordBot.ts
+++ b/packages/entrypoints/src/discordBot.ts
@@ -12,6 +12,7 @@ import { GenerateMonthlyUsageReport } from "@tf2qs/core";
 import { GetServerStatus } from "@tf2qs/core";
 import { GetGuildServers } from "@tf2qs/core";
 import { GetUserServers } from "@tf2qs/core";
+import { GetSourceTvInfo } from "@tf2qs/core";
 import { SetUserData } from "@tf2qs/core";
 import { TerminateEmptyServers } from "@tf2qs/core";
 import { TerminateLongRunningServers } from "@tf2qs/core";
@@ -397,6 +398,7 @@ export async function startDiscordBot() {
             getUserServers: new GetUserServers({ serverRepository }),
             backgroundTaskQueue,
             serverRepository,
+            getSourceTvInfo: new GetSourceTvInfo({ serverRepository }),
         }
     })
 

--- a/packages/entrypoints/src/http/middlewares/requireScope.ts
+++ b/packages/entrypoints/src/http/middlewares/requireScope.ts
@@ -1,0 +1,36 @@
+import { NextFunction, Request, RequestHandler, Response } from 'express';
+import { logger } from '@tf2qs/telemetry';
+
+export function createRequireScopeMiddleware(requiredScope: string): RequestHandler {
+    return (req: Request, res: Response, next: NextFunction) => {
+        const payload = req.auth?.payload;
+        const scope = payload?.scope;
+        const permissions = payload?.permissions;
+
+        const scopes = typeof scope === 'string' ? scope.split(' ') : [];
+        const permissionList = Array.isArray(permissions)
+            ? (permissions as unknown[]).filter((permission): permission is string => typeof permission === 'string')
+            : [];
+
+        if (!scopes.includes(requiredScope) && !permissionList.includes(requiredScope)) {
+            const clientId = [payload?.azp, payload?.sub].find((value): value is string => typeof value === 'string');
+            logger.emit({
+                severityText: 'WARN',
+                body: 'Forbidden: missing required scope',
+                attributes: {
+                    requiredScope,
+                    path: req.path,
+                    method: req.method,
+                    clientId,
+                },
+            });
+            res.status(403).json({
+                error: 'Forbidden',
+                message: `Missing required scope: ${requiredScope}`,
+            });
+            return;
+        }
+
+        next();
+    };
+}

--- a/packages/entrypoints/src/http/routes/api.ts
+++ b/packages/entrypoints/src/http/routes/api.ts
@@ -2,11 +2,13 @@ import { Express } from 'express';
 import swaggerJsdoc from 'swagger-jsdoc';
 import swaggerUi from 'swagger-ui-express';
 import { profileHandler } from '../middlewares/profile';
+import { createRequireScopeMiddleware } from '../middlewares/requireScope';
 import { createListServersHandler } from './servers/listServers';
 import { createCreateServerHandler } from './servers/createServer';
 import { createDeleteServerHandler } from './servers/deleteServer';
 import { createGetTaskStatusHandler } from './tasks/getTaskStatus';
-import { BackgroundTaskQueue, GetUserServers, ServerRepository } from '@tf2qs/core';
+import { createGetSourceTvInfoHandler } from './sourcetv/getSourceTvInfo';
+import { BackgroundTaskQueue, GetUserServers, GetSourceTvInfo, ServerRepository } from '@tf2qs/core';
 import { swaggerOptions } from './swaggerOptions';
 
 const swaggerSpec = swaggerJsdoc(swaggerOptions);
@@ -15,6 +17,7 @@ export type ApiRouteDependencies = {
     getUserServers: GetUserServers;
     backgroundTaskQueue: BackgroundTaskQueue;
     serverRepository: ServerRepository;
+    getSourceTvInfo: GetSourceTvInfo;
 };
 
 export function registerApiRoutes(app: Express, dependencies: ApiRouteDependencies) {
@@ -23,10 +26,11 @@ export function registerApiRoutes(app: Express, dependencies: ApiRouteDependenci
     app.use('/api/docs', swaggerUi.serve, swaggerUi.setup(swaggerSpec));
     app.get('/api/openapi.json', (_req, res) => { res.json(swaggerSpec); });
 
-    const { getUserServers, backgroundTaskQueue, serverRepository } = dependencies;
-    app.get('/api/servers', createListServersHandler(getUserServers));
-    app.post('/api/servers', createCreateServerHandler(backgroundTaskQueue));
-    app.delete('/api/servers/:serverId', createDeleteServerHandler(backgroundTaskQueue, serverRepository));
-    app.get('/api/tasks/:taskId', createGetTaskStatusHandler(backgroundTaskQueue));
+    const { getUserServers, backgroundTaskQueue, serverRepository, getSourceTvInfo } = dependencies;
+    app.get('/api/servers', createRequireScopeMiddleware('manage:servers'), createListServersHandler(getUserServers));
+    app.post('/api/servers', createRequireScopeMiddleware('manage:servers'), createCreateServerHandler(backgroundTaskQueue));
+    app.delete('/api/servers/:serverId', createRequireScopeMiddleware('manage:servers'), createDeleteServerHandler(backgroundTaskQueue, serverRepository));
+    app.get('/api/tasks/:taskId', createRequireScopeMiddleware('manage:servers'), createGetTaskStatusHandler(backgroundTaskQueue));
+    app.get('/api/sourcetv-connections', createRequireScopeMiddleware('read:sourcetv:all'), createGetSourceTvInfoHandler(getSourceTvInfo));
 }
 

--- a/packages/entrypoints/src/http/routes/openapi.test.ts
+++ b/packages/entrypoints/src/http/routes/openapi.test.ts
@@ -42,4 +42,50 @@ describe('GET /api/openapi.json', () => {
         expect(paths.some((p) => p.includes('servers'))).toBe(true);
         expect(paths.some((p) => p.includes('tasks'))).toBe(true);
     });
+
+    it('should include the SourceTV endpoint and schema in the spec', async () => {
+        // Given
+        const { app } = makeSut();
+
+        // When
+        const response = await request(app).get('/api/openapi.json');
+
+        // Then
+        expect(response.body.paths['/api/sourcetv-connections']).toBeDefined();
+        expect(response.body.components.schemas.SourceTvInfo).toBeDefined();
+    });
+
+    it('should declare the two API scopes in the oauth2 security scheme', async () => {
+        // Given
+        const { app } = makeSut();
+
+        // When
+        const response = await request(app).get('/api/openapi.json');
+
+        // Then
+        const scopes = response.body.components.securitySchemes.oauth2.flows.clientCredentials.scopes;
+        expect(scopes).toMatchObject({
+            'manage:servers': expect.any(String),
+            'read:sourcetv:all': expect.any(String),
+        });
+    });
+
+    it('should require the correct scope on each endpoint', async () => {
+        // Given
+        const { app } = makeSut();
+
+        // When
+        const response = await request(app).get('/api/openapi.json');
+
+        // Then
+        const paths = response.body.paths;
+        const serverSecurity = paths['/api/servers'].get.security;
+        const sourcetvSecurity = paths['/api/sourcetv-connections'].get.security;
+        expect(serverSecurity).toEqual(
+            expect.arrayContaining([expect.objectContaining({ oauth2: ['manage:servers'] })])
+        );
+        expect(sourcetvSecurity).toEqual(
+            expect.arrayContaining([expect.objectContaining({ oauth2: ['read:sourcetv:all'] })])
+        );
+    });
 });

--- a/packages/entrypoints/src/http/routes/servers/createServer.test.ts
+++ b/packages/entrypoints/src/http/routes/servers/createServer.test.ts
@@ -1,7 +1,7 @@
 import request from 'supertest';
 import { describe, it, expect } from 'vitest';
 import { when } from 'vitest-when';
-import { makeSut, TEST_CLIENT_ID } from '../testHelpers';
+import { makeSut, TEST_CLIENT_ID, injectAuth } from '../testHelpers';
 
 describe('POST /api/servers', () => {
     it('should return 202 with a taskId when request is valid', async () => {
@@ -90,5 +90,20 @@ describe('POST /api/servers', () => {
         // Then
         expect(response.status).toBe(400);
         expect(response.body).toMatchObject({ error: 'Bad Request' });
+    });
+
+    it('should return 403 when the client lacks the manage:servers scope', async () => {
+        // Given
+        const { app, backgroundTaskQueue } = makeSut(injectAuth(TEST_CLIENT_ID, 'read:sourcetv:all'));
+
+        // When
+        const response = await request(app)
+            .post('/api/servers')
+            .send({ region: 'sa-saopaulo-1', variantName: 'standard-competitive' });
+
+        // Then
+        expect(response.status).toBe(403);
+        expect(response.body).toMatchObject({ error: 'Forbidden' });
+        expect(backgroundTaskQueue.enqueue).not.toHaveBeenCalled();
     });
 });

--- a/packages/entrypoints/src/http/routes/servers/createServer.ts
+++ b/packages/entrypoints/src/http/routes/servers/createServer.ts
@@ -13,10 +13,12 @@ export function createCreateServerHandler(backgroundTaskQueue: BackgroundTaskQue
      *       Enqueues a server creation task and returns a task ID immediately.
      *       Server creation typically takes 4-6 minutes. Poll `GET /api/tasks/{taskId}` to check status.
      *       When completed, the task result contains the full server details including credentials.
+     *       Requires the `manage:servers` scope.
      *     tags:
      *       - Servers
      *     security:
      *       - bearerAuth: []
+     *       - oauth2: [manage:servers]
      *     requestBody:
      *       required: true
      *       content:

--- a/packages/entrypoints/src/http/routes/servers/deleteServer.test.ts
+++ b/packages/entrypoints/src/http/routes/servers/deleteServer.test.ts
@@ -1,7 +1,7 @@
 import request from 'supertest';
 import { describe, it, expect } from 'vitest';
 import { when } from 'vitest-when';
-import { makeSut, makeServer, TEST_CLIENT_ID } from '../testHelpers';
+import { makeSut, makeServer, TEST_CLIENT_ID, injectAuth } from '../testHelpers';
 
 describe('DELETE /api/servers/:serverId', () => {
     it('should return 202 with a taskId when the client owns the server', async () => {
@@ -46,5 +46,18 @@ describe('DELETE /api/servers/:serverId', () => {
         // Then
         expect(response.status).toBe(403);
         expect(response.body).toMatchObject({ error: 'Forbidden' });
+    });
+
+    it('should return 403 when the client lacks the manage:servers scope', async () => {
+        // Given
+        const { app, backgroundTaskQueue } = makeSut(injectAuth(TEST_CLIENT_ID, 'read:sourcetv:all'));
+
+        // When
+        const response = await request(app).delete('/api/servers/server-xyz');
+
+        // Then
+        expect(response.status).toBe(403);
+        expect(response.body).toMatchObject({ error: 'Forbidden' });
+        expect(backgroundTaskQueue.enqueue).not.toHaveBeenCalled();
     });
 });

--- a/packages/entrypoints/src/http/routes/servers/deleteServer.ts
+++ b/packages/entrypoints/src/http/routes/servers/deleteServer.ts
@@ -12,10 +12,12 @@ export function createDeleteServerHandler(backgroundTaskQueue: BackgroundTaskQue
      *       Enqueues a server deletion task and returns a task ID immediately.
      *       Server deletion typically takes 1-3 minutes. Poll `GET /api/tasks/{taskId}` to check status.
      *       Only the client that created the server may delete it.
+     *       Requires the `manage:servers` scope.
      *     tags:
      *       - Servers
      *     security:
      *       - bearerAuth: []
+     *       - oauth2: [manage:servers]
      *     parameters:
      *       - in: path
      *         name: serverId

--- a/packages/entrypoints/src/http/routes/servers/listServers.test.ts
+++ b/packages/entrypoints/src/http/routes/servers/listServers.test.ts
@@ -1,7 +1,7 @@
 import request from 'supertest';
 import { describe, it, expect } from 'vitest';
 import { when } from 'vitest-when';
-import { makeSut, makeServer, TEST_CLIENT_ID } from '../testHelpers';
+import { makeSut, makeServer, TEST_CLIENT_ID, injectAuth } from '../testHelpers';
 
 describe('GET /api/servers', () => {
     it('should return the list of servers for the authenticated client', async () => {
@@ -60,5 +60,18 @@ describe('GET /api/servers', () => {
 
         // Then
         expect(getUserServers.execute).toHaveBeenCalledWith({ userId: TEST_CLIENT_ID });
+    });
+
+    it('should return 403 when the client lacks the manage:servers scope', async () => {
+        // Given
+        const { app, getUserServers } = makeSut(injectAuth(TEST_CLIENT_ID, 'read:sourcetv:all'));
+
+        // When
+        const response = await request(app).get('/api/servers');
+
+        // Then
+        expect(response.status).toBe(403);
+        expect(response.body).toMatchObject({ error: 'Forbidden' });
+        expect(getUserServers.execute).not.toHaveBeenCalled();
     });
 });

--- a/packages/entrypoints/src/http/routes/sourcetv/getSourceTvInfo.test.ts
+++ b/packages/entrypoints/src/http/routes/sourcetv/getSourceTvInfo.test.ts
@@ -1,0 +1,90 @@
+import request from 'supertest';
+import { describe, it, expect } from 'vitest';
+import { when } from 'vitest-when';
+import { SourceTvInfo } from '@tf2qs/core';
+import { makeSut, injectAuth, TEST_CLIENT_ID } from '../testHelpers';
+
+const SOURCETV_SCOPE = 'read:sourcetv:all';
+
+describe('GET /api/sourcetv-connections', () => {
+    it('should return SourceTV info for all ready servers when the client has the required scope', async () => {
+        // Given
+        const { app, getSourceTvInfo } = makeSut(injectAuth(TEST_CLIENT_ID, SOURCETV_SCOPE));
+        const sourceTvInfo: SourceTvInfo[] = [
+            {
+                serverId: 'server-abc',
+                hostIp: '1.2.3.4',
+                hostPort: 27015,
+                tvIp: '1.2.3.4',
+                tvPort: 27020,
+                tvPassword: 'tv123',
+            },
+        ];
+        when(getSourceTvInfo.execute).calledWith().thenResolve(sourceTvInfo);
+
+        // When
+        const response = await request(app).get('/api/sourcetv-connections');
+
+        // Then
+        expect(response.status).toBe(200);
+        expect(response.body).toEqual(sourceTvInfo);
+        expect(getSourceTvInfo.execute).toHaveBeenCalledWith();
+    });
+
+    it('should return an empty array when there are no ready servers', async () => {
+        // Given
+        const { app, getSourceTvInfo } = makeSut(injectAuth(TEST_CLIENT_ID, SOURCETV_SCOPE));
+        when(getSourceTvInfo.execute).calledWith().thenResolve([]);
+
+        // When
+        const response = await request(app).get('/api/sourcetv-connections');
+
+        // Then
+        expect(response.status).toBe(200);
+        expect(response.body).toEqual([]);
+    });
+
+    it('should return 403 when the client does not have the required scope', async () => {
+        // Given
+        const { app, getSourceTvInfo } = makeSut(injectAuth(TEST_CLIENT_ID, 'manage:servers'));
+
+        // When
+        const response = await request(app).get('/api/sourcetv-connections');
+
+        // Then
+        expect(response.status).toBe(403);
+        expect(response.body).toMatchObject({
+            error: 'Forbidden',
+            message: expect.stringContaining(SOURCETV_SCOPE),
+        });
+        expect(getSourceTvInfo.execute).not.toHaveBeenCalled();
+    });
+
+    it('should return 403 when the token has no scope claim', async () => {
+        // Given
+        const { app, getSourceTvInfo } = makeSut(injectAuth(TEST_CLIENT_ID));
+
+        // When
+        const response = await request(app).get('/api/sourcetv-connections');
+
+        // Then
+        expect(response.status).toBe(403);
+        expect(getSourceTvInfo.execute).not.toHaveBeenCalled();
+    });
+
+    it('should not expose rcon or host passwords', async () => {
+        // Given
+        const { app, getSourceTvInfo } = makeSut(injectAuth(TEST_CLIENT_ID, SOURCETV_SCOPE));
+        when(getSourceTvInfo.execute)
+            .calledWith()
+            .thenResolve([{ serverId: 'server-abc', hostIp: '1.2.3.4', hostPort: 27015, tvIp: '1.2.3.4', tvPort: 27020, tvPassword: 'tv123' }]);
+
+        // When
+        const response = await request(app).get('/api/sourcetv-connections');
+
+        // Then
+        expect(response.status).toBe(200);
+        expect(response.body[0]).not.toHaveProperty('rconPassword');
+        expect(response.body[0]).not.toHaveProperty('hostPassword');
+    });
+});

--- a/packages/entrypoints/src/http/routes/sourcetv/getSourceTvInfo.ts
+++ b/packages/entrypoints/src/http/routes/sourcetv/getSourceTvInfo.ts
@@ -1,37 +1,41 @@
 import { Request, Response } from 'express';
-import { GetUserServers } from '@tf2qs/core';
+import { GetSourceTvInfo } from '@tf2qs/core';
 import { logger } from '@tf2qs/telemetry';
 
-export function createListServersHandler(getUserServers: GetUserServers) {
+export function createGetSourceTvInfoHandler(getSourceTvInfo: GetSourceTvInfo) {
     /**
      * @openapi
-     * /api/servers:
+     * /api/sourcetv-connections:
      *   get:
-     *     summary: List all servers for the authenticated client
-     *     description: Returns all TF2 game servers associated with the authenticated API client. Requires the `manage:servers` scope.
+     *     summary: List SourceTV information for all servers
+     *     description: |
+     *       Returns SourceTV connection information for all ready TF2 game servers across QuickServer.
+     *       Requires the `read:sourcetv:all` scope. RCON and server join passwords are never exposed.
      *     tags:
-     *       - Servers
+     *       - SourceTV
      *     security:
      *       - bearerAuth: []
-     *       - oauth2: [manage:servers]
+     *       - oauth2: [read:sourcetv:all]
      *     responses:
      *       200:
-     *         description: A list of servers
+     *         description: A list of SourceTV information for all ready servers
      *         content:
      *           application/json:
      *             schema:
      *               type: array
      *               items:
-     *                 $ref: '#/components/schemas/Server'
+     *                 $ref: '#/components/schemas/SourceTvInfo'
      *       401:
      *         $ref: '#/components/responses/Unauthorized'
+     *       403:
+     *         $ref: '#/components/responses/Forbidden'
      */
     return async (req: Request, res: Response): Promise<void> => {
         const clientId = req.auth?.payload.azp || req.auth?.payload.sub;
         if (!clientId) {
             logger.emit({
                 severityText: 'WARN',
-                body: 'List servers request with no client ID in token',
+                body: 'SourceTV info request with no client ID in token',
                 attributes: { path: req.path, method: req.method },
             });
             res.status(401).json({ error: 'Unauthorized', message: 'No client ID found in token' });
@@ -40,18 +44,18 @@ export function createListServersHandler(getUserServers: GetUserServers) {
 
         logger.emit({
             severityText: 'INFO',
-            body: 'List servers request received',
+            body: 'SourceTV info request received',
             attributes: { clientId: clientId as string },
         });
 
-        const servers = await getUserServers.execute({ userId: clientId as string });
+        const sourceTvInfo = await getSourceTvInfo.execute();
 
         logger.emit({
             severityText: 'INFO',
-            body: 'List servers response',
-            attributes: { clientId: clientId as string, serverCount: servers.length },
+            body: 'SourceTV info response',
+            attributes: { clientId: clientId as string, serverCount: sourceTvInfo.length },
         });
 
-        res.json(servers);
+        res.json(sourceTvInfo);
     };
 }

--- a/packages/entrypoints/src/http/routes/swaggerOptions.ts
+++ b/packages/entrypoints/src/http/routes/swaggerOptions.ts
@@ -29,7 +29,10 @@ export const swaggerOptions: swaggerJsdoc.Options = {
                     flows: {
                         clientCredentials: {
                             tokenUrl: 'https://tf2-quickserver.us.auth0.com/oauth/token',
-                            scopes: {},
+                            scopes: {
+                                'manage:servers': 'Manage TF2 servers (list, create, delete, and task status)',
+                                'read:sourcetv:all': 'Read SourceTV connection info for all servers',
+                            },
                         },
                     },
                 },
@@ -52,6 +55,18 @@ export const swaggerOptions: swaggerJsdoc.Options = {
                         createdAt: { type: 'string', format: 'date-time' },
                         createdBy: { type: 'string', description: 'Client ID of the creator' },
                         status: { type: 'string', enum: ['pending', 'ready', 'terminating'] },
+                    },
+                },
+                SourceTvInfo: {
+                    type: 'object',
+                    description: 'SourceTV connection information for a ready server. RCON and join passwords are never included.',
+                    properties: {
+                        serverId: { type: 'string', example: 'a1b2c3d4-e5f6-7890-abcd-ef1234567890' },
+                        hostIp: { type: 'string', example: '1.2.3.4' },
+                        hostPort: { type: 'integer', example: 27015 },
+                        tvIp: { type: 'string', example: '1.2.3.4' },
+                        tvPort: { type: 'integer', example: 27020 },
+                        tvPassword: { type: 'string', example: 'tvpass123', description: 'SourceTV password (omitted when not set)' },
                     },
                 },
                 CreateServerRequest: {
@@ -136,5 +151,7 @@ export const swaggerOptions: swaggerJsdoc.Options = {
         path.join(__dirname, '../routes/servers/*.js'),
         path.join(__dirname, '../routes/tasks/*.ts'),
         path.join(__dirname, '../routes/tasks/*.js'),
+        path.join(__dirname, '../routes/sourcetv/*.ts'),
+        path.join(__dirname, '../routes/sourcetv/*.js'),
     ],
 };

--- a/packages/entrypoints/src/http/routes/tasks/getTaskStatus.test.ts
+++ b/packages/entrypoints/src/http/routes/tasks/getTaskStatus.test.ts
@@ -2,7 +2,7 @@ import request from 'supertest';
 import { describe, it, expect } from 'vitest';
 import { when } from 'vitest-when';
 import { TaskStatus } from '@tf2qs/core';
-import { makeSut, makeServer, TEST_CLIENT_ID } from '../testHelpers';
+import { makeSut, makeServer, TEST_CLIENT_ID, injectAuth } from '../testHelpers';
 
 describe('GET /api/tasks/:taskId', () => {
     it('should return the task status for a known taskId owned by the requester', async () => {
@@ -105,5 +105,18 @@ describe('GET /api/tasks/:taskId', () => {
         // Then
         expect(response.status).toBe(200);
         expect(response.body.status).toBe(status);
+    });
+
+    it('should return 403 when the client lacks the manage:servers scope', async () => {
+        // Given
+        const { app, backgroundTaskQueue } = makeSut(injectAuth(TEST_CLIENT_ID, 'read:sourcetv:all'));
+
+        // When
+        const response = await request(app).get('/api/tasks/task-123');
+
+        // Then
+        expect(response.status).toBe(403);
+        expect(response.body).toMatchObject({ error: 'Forbidden' });
+        expect(backgroundTaskQueue.getTask).not.toHaveBeenCalled();
     });
 });

--- a/packages/entrypoints/src/http/routes/tasks/getTaskStatus.ts
+++ b/packages/entrypoints/src/http/routes/tasks/getTaskStatus.ts
@@ -12,10 +12,12 @@ export function createGetTaskStatusHandler(backgroundTaskQueue: BackgroundTaskQu
      *       (e.g. server creation or deletion). When `status` is `completed`, the `result`
      *       field contains the full server object. When `status` is `failed`, the `error`
      *       field contains the failure reason.
+     *       Requires the `manage:servers` scope.
      *     tags:
      *       - Tasks
      *     security:
      *       - bearerAuth: []
+     *       - oauth2: [manage:servers]
      *     parameters:
      *       - in: path
      *         name: taskId

--- a/packages/entrypoints/src/http/routes/testHelpers.ts
+++ b/packages/entrypoints/src/http/routes/testHelpers.ts
@@ -1,14 +1,20 @@
-import { Request, Response, NextFunction } from 'express';
+import { Request, Response, NextFunction, RequestHandler } from 'express';
 import { mock } from 'vitest-mock-extended';
-import { GetUserServers, BackgroundTaskQueue, ServerRepository, Server } from '@tf2qs/core';
+import { GetUserServers, BackgroundTaskQueue, ServerRepository, Server, GetSourceTvInfo } from '@tf2qs/core';
 import { Region } from '@tf2qs/core';
 import { initializeExpress } from '../express';
 
 export const TEST_CLIENT_ID = 'test-client-abc123';
 
-export function injectAuth(clientId: string) {
+export function injectAuth(clientId: string, scope?: string) {
     return (req: Request, _res: Response, next: NextFunction) => {
-        (req as any).auth = { payload: { azp: clientId, sub: clientId } };
+        (req as any).auth = {
+            payload: {
+                azp: clientId,
+                sub: clientId,
+                ...(scope ? { scope } : {}),
+            },
+        };
         next();
     };
 }
@@ -32,15 +38,16 @@ export function makeServer(overrides: Partial<Server> = {}): Server {
     };
 }
 
-export function makeSut() {
+export function makeSut(authMiddlewareOverride?: RequestHandler) {
     const getUserServers = mock<GetUserServers>();
     const backgroundTaskQueue = mock<BackgroundTaskQueue>();
     const serverRepository = mock<ServerRepository>();
+    const getSourceTvInfo = mock<GetSourceTvInfo>();
 
     const app = initializeExpress({
-        apiDependencies: { getUserServers, backgroundTaskQueue, serverRepository },
-        authMiddlewareOverride: injectAuth(TEST_CLIENT_ID),
+        apiDependencies: { getUserServers, backgroundTaskQueue, serverRepository, getSourceTvInfo },
+        authMiddlewareOverride: authMiddlewareOverride ?? injectAuth(TEST_CLIENT_ID, 'manage:servers'),
     });
 
-    return { app, getUserServers, backgroundTaskQueue, serverRepository };
+    return { app, getUserServers, backgroundTaskQueue, serverRepository, getSourceTvInfo };
 }


### PR DESCRIPTION
## Summary

Adds a new HTTP endpoint that lets partners monitor SourceTV across all QuickServer servers, and introduces scope-based authorization to the API.

### New endpoint: `GET /api/sourcetv-connections`

Returns SourceTV connection info for all **ready** servers across QuickServer:

```json
[
  {
    "serverId": "a1b2c3d4-...",
    "hostIp": "1.2.3.4",
    "hostPort": 27015,
    "tvIp": "1.2.3.4",
    "tvPort": 27020,
    "tvPassword": "tvpass123"
  }
]
```

- Gated by the new **`read:sourcetv:all`** scope — clients without it get `403`.
- **RCON and join passwords are never exposed** — the response only carries server IP/port, TV address, and TV password.
- Only `ready` servers are returned (pending/terminating servers have no usable STV address).

### Scope-based authorization

The API now has exactly two scopes:

| Scope | Endpoints |
|---|---|
| `manage:servers` | `GET/POST /api/servers`, `DELETE /api/servers/{serverId}`, `GET /api/tasks/{taskId}` |
| `read:sourcetv:all` | `GET /api/sourcetv-connections` |

`GET /api/profile` remains available to any authenticated client and shows the scopes it holds. This is the first scope-enforced endpoint set in the API; existing behavior is unchanged for clients that already hold the relevant scopes.

### Key implementation details

- New `GetSourceTvInfo` use case in `@tf2qs/core` — fetches all servers, filters to `ready`, maps to a safe DTO.
- New `createRequireScopeMiddleware` — checks the JWT `scope` claim (space-separated) or `permissions` array, returns `403` when missing.
- OpenAPI spec updated: `SourceTvInfo` schema, per-endpoint scope requirements, and the two scopes declared in the `oauth2` flow. `docs/api/openapi.yaml` regenerated via `npm run gen:openapi`.
- `docs/oauth.md` documents the two scopes and the endpoint mapping.
