### PR TITLE
feat(variants): ozfortress AHH 2026 charity event support

### DIFF
--- a/config/default.json
+++ b/config/default.json
@@ -464,6 +464,17 @@
             },
             "guildId": "1243180086031679488"
         },
+        "ozfortress-ahh": {
+            "displayName": "ozfortress AHH",
+            "hostname": "ozfortress AHH | {region} @ TF2-QuickServer",
+            "map": "plr_hightower",
+            "defaultCfgs": {
+                "plr_hightower": "ahh_plr.cfg",
+                "plr_hightower_event": "ahh_plr.cfg",
+                "koth_snowtower": "ahh_koth.cfg"
+            },
+            "guildId": "82651383144120320"
+        },
         "cltf2": {
             "displayName": "CLTF2",
             "hostname": "CLTF2 | {region} @ TF2-QuickServer",

--- a/maps.json
+++ b/maps.json
@@ -152,5 +152,7 @@
         "url": "https://tf2maps.net/downloads/glassworks.46/download"
     },
     "koth_gamma_rc1",
-    "koth_coalplant_b7"
+    "koth_coalplant_b7",
+    "plr_hightower",
+    "plr_hightower_event"
 ]

--- a/variants/base/maps_to_keep
+++ b/variants/base/maps_to_keep
@@ -1,1 +1,4 @@
 cp_badlands
+koth_snowtower
+plr_hightower
+plr_hightower_event

--- a/variants/base/tf/scripts/vscripts/htimer.nut
+++ b/variants/base/tf/scripts/vscripts/htimer.nut
@@ -1,0 +1,29 @@
+::HTimer <- {}
+
+function HTimer::OnGameEvent_teamplay_round_start(params)
+{
+    local old = Entities.FindByName(null, "custom_timer")
+    if (old != null)
+        old.Kill()
+
+    SpawnEntityFromTable("team_round_timer", {
+        targetname = "custom_timer",
+        timer_length = 1800,
+        max_length = 1800,
+        start_paused = 0,
+        show_in_hud = 1,
+        auto_countdown = 1,
+        "OnFinished#1": "custom_win,RoundWin,,0,-1"
+    })
+
+    SpawnEntityFromTable("game_round_win", {
+        targetname = "custom_win",
+        TeamNum = 0,
+        force_map_reset = 1
+    })
+
+    EntFire("custom_timer", "Enable", "", 0.5)
+    EntFire("custom_timer", "ShowInHUD", "1", 0.5)
+}
+
+__CollectGameEventCallbacks(HTimer)

--- a/variants/fat-standard-competitive-i386/Dockerfile
+++ b/variants/fat-standard-competitive-i386/Dockerfile
@@ -295,6 +295,9 @@ COPY --chown=tf2 variants/base/tf/addons/sourcemod/extensions/* "${SERVER_DIR}/t
 # Copy maps
 COPY --chown=tf2 maps/ "${SERVER_DIR}/tf/maps/"
 
+# Copy vscripts
+COPY --chown=tf2 variants/base/tf/scripts/vscripts/ "${SERVER_DIR}/tf/scripts/vscripts/"
+
 # Copy custom entrypoint
 COPY --chown=tf2 variants/base/enforced_cvars.cfg $SERVER_DIR/enforced_cvars.cfg
 COPY --chown=tf2 variants/base/custom_entrypoint.sh .


### PR DESCRIPTION
## Summary

Adds support for the [ozfortress Australian Hightower Highjinx 2026 charity event](https://ozfortress.com/leagues/97) on TF2-QuickServer servers.

## Changes

- **VScript** (`variants/base/tf/scripts/vscripts/htimer.nut`): vendored verbatim from ozfortress. On each round start it spawns a HUD round timer (30 min for PLR maps) and a `game_round_win` entity when the timer finishes.
- **Dockerfile** (`variants/fat-standard-competitive-i386/Dockerfile`): copies the whole `variants/base/tf/scripts/vscripts/` folder into `tf/scripts/vscripts/`. Future vscripts can be dropped into the folder with no Dockerfile change.
- **Maps** (`maps.json`, `variants/base/maps_to_keep`): added `plr_hightower`, `plr_hightower_event` and `koth_snowtower`. All three are official Valve maps shipped with the dedicated-server depot, so they are retained via `maps_to_keep` instead of FastDL (`koth_snowtower` is not on any FastDL mirror, but every client has it installed).
- **Variant** (`config/default.json`): new `ozfortress-ahh` variant for the ozfortress guild (`82651383144120320`). Uses per-map `defaultCfgs` keys so the container entrypoint generates `tf/cfg/plr_hightower.cfg` → `exec ahh_plr.cfg`, `tf/cfg/plr_hightower_event.cfg` → `exec ahh_plr.cfg` and `tf/cfg/koth_snowtower.cfg` → `exec ahh_koth.cfg`, which TF2 auto-executes on map load. Per-map keys are required because `plr_` maps would otherwise fall into the `pl_*` (`DEFAULT_PL_CFG`) bucket.

## VScript isolation

The AHH cfg files (`ahh_plr.cfg`, `ahh_koth.cfg`, `ahh_whitelist_hl.txt`) already ship in the image via the existing `ozfortress/server-configs` master `cfg/*` download. `ahh_plr.cfg` is the only cfg that runs `sv_cheats 1; script_execute htimer; sv_cheats 0`. A `.nut` file in `tf/scripts/vscripts/` is completely inert unless explicitly executed (verified against Valve VScript docs and via repo-wide grep) — no entrypoint or global config changes, so other variants/users of the standard-competitive image are unaffected.

## Verification

- Vendored `.nut` is byte-identical to the ozfortress-provided file.
- `maps.json` and `config/default.json` JSON-valid (CI validates the latter).
- Repo-wide grep confirms `script_execute htimer` appears only in `ahh_plr.cfg` (upstream).
- Image verification (`docker run ... ls tf/scripts/vscripts/htimer.nut tf/cfg/ahh_*.cfg`) is a manual post-merge step alongside the next `build:fat:standard-competitive-i386` + `push:fat` run; the server image must be rebuilt/pushed before the `ozfortress-ahh` variant can serve the AHH maps.
