### PR TITLE
perf(variants): slim fat-standard-competitive-i386 + CI image size gate

### DIFF
--- a/.github/workflows/build-variant.yaml
+++ b/.github/workflows/build-variant.yaml
@@ -79,6 +79,9 @@ jobs:
       - name: Build ${{ inputs.variant-name }} image
         run: docker build -f ${{ inputs.dockerfile-path }} -t ${{ inputs.image-name }}:latest .
 
+      - name: Check image size (OCI Container Instances limit)
+        run: bash ./packages/scripts/check_image_size.sh ${{ inputs.image-name }}:latest
+
       - name: Run container and check health
         run: bash ./packages/scripts/test_image.sh ${{ inputs.image-name }}:latest
 

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "build:fat:mge-tf": "docker build -t sonikro/fat-mge-tf:latest -f ./variants/fat-mge-tf/Dockerfile .",
     "build:fat:tf2center": "docker build -t sonikro/fat-tf2center:latest -f ./variants/fat-tf2center/Dockerfile .",
     "push:fat:mge-tf": "docker push sonikro/fat-mge-tf:latest",
+    "test:image-size": "bash ./packages/scripts/check_image_size.sh",
     "build:backend": "tsc"
   },
   "repository": {

--- a/packages/scripts/check_image_size.sh
+++ b/packages/scripts/check_image_size.sh
@@ -1,0 +1,56 @@
+#!/bin/bash
+# Usage: ./packages/scripts/check_image_size.sh <image_name> [max_size_gb]
+#
+# OCI Container Instances provide a fixed 15 GB ephemeral storage shared by the
+# container image and the container's writable overlay. Oracle recommends the
+# image stay under 7.5 GB so pull/unpack has headroom. Failing builds above the
+# limit prevents pushing images that cannot start in production.
+#
+# Override the limit with OCI_MAX_IMAGE_SIZE_GB env var or the second argument.
+#
+set -euo pipefail
+
+IMAGE_NAME="${1:-}"
+MAX_SIZE_GB="${2:-${OCI_MAX_IMAGE_SIZE_GB:-14}}"
+
+if [[ -z "$IMAGE_NAME" ]]; then
+  echo "Usage: $0 <image_name> [max_size_gb]"
+  exit 2
+fi
+
+if ! command -v docker >/dev/null 2>&1; then
+  echo "[ERROR] docker is not available"; exit 2
+fi
+
+CID=$(docker create --entrypoint /bin/true "$IMAGE_NAME")
+cleanup() {
+  docker rm -f "$CID" >/dev/null 2>&1 || true
+}
+trap cleanup EXIT
+
+echo "[INFO] Measuring extracted filesystem size of '$IMAGE_NAME' (this may take a while)..."
+ROOTFS_BYTES=$(docker export "$CID" | wc -c)
+INSPECT_BYTES=$(docker image inspect "$IMAGE_NAME" --format '{{.Size}}')
+
+LIMIT_BYTES=$(awk -v gb="$MAX_SIZE_GB" 'BEGIN { printf "%.0f", gb * 1024 * 1024 * 1024 }')
+ROOTFS_GB=$(awk -v b="$ROOTFS_BYTES" 'BEGIN { printf "%.2f", b / (1024 * 1024 * 1024) }')
+INSPECT_GB=$(awk -v b="$INSPECT_BYTES" 'BEGIN { printf "%.2f", b / (1024 * 1024 * 1024) }')
+
+echo "[INFO] Extracted filesystem: ${ROOTFS_GB} GB"
+echo "[INFO] Engine-reported image size: ${INSPECT_GB} GB"
+echo "[INFO] Max allowed (OCI ephemeral storage headroom): ${MAX_SIZE_GB} GB"
+
+FAILURE=0
+if (( ROOTFS_BYTES > LIMIT_BYTES )); then
+  echo "[ERROR] Image extracted filesystem (${ROOTFS_GB} GB) exceeds the ${MAX_SIZE_GB} GB limit for OCI Container Instances."; FAILURE=1
+fi
+if (( INSPECT_BYTES > LIMIT_BYTES )); then
+  echo "[ERROR] Image stored size (${INSPECT_GB} GB) exceeds the ${MAX_SIZE_GB} GB limit for OCI Container Instances."; FAILURE=1
+fi
+
+if (( FAILURE == 1 )); then
+  echo "[ACTION] Trim image fat (maps janitorial pruning, unused binaries, docker build cache) before pushing."
+  exit 1
+fi
+
+echo "[SUCCESS] Image fits within the OCI Container Instances ephemeral storage limit."

--- a/variants/README.md
+++ b/variants/README.md
@@ -166,6 +166,23 @@ npm run download:maps
 docker build -f variants/fat-standard-competitive/Dockerfile -t my-tf2-server .
 ```
 
+## 📏 Image Size Check (OCI Container Instances)
+
+OCI Container Instances provide a fixed **15 GB ephemeral storage** shared between
+the container image and the container's writable overlay, and Oracle recommends
+keeping the image under **7.5 GB** so pull/unpack has headroom. To prevent
+pushing an image that cannot start in production, CI and local builds validate
+the extracted filesystem size:
+
+```bash
+npm run test:image-size sonikro/fat-tf2-standard-competitive-i386:latest
+```
+
+The limit defaults to 14 GB and can be overridden per run with
+`OCI_MAX_IMAGE_SIZE_GB` or as the second positional argument. The check runs in
+the build workflow (`.github/workflows/build-variant.yaml`) on every variant
+push and fails the build when the image exceeds it.
+
 ---
 
 ## 🔗 Related Links

--- a/variants/fat-standard-competitive-i386/Dockerfile
+++ b/variants/fat-standard-competitive-i386/Dockerfile
@@ -190,9 +190,6 @@ RUN export DEBIAN_FRONTEND=noninteractive \
   && export TZ=Etc/UTC \
   && dpkg --add-architecture i386 \
   && apt-get -y update \
-  && apt-get install -y software-properties-common \
-  && add-apt-repository multiverse \
-  && apt-get -y update \
   && apt-get install -y --no-install-recommends --no-install-suggests \
   lib32gcc-s1 \
   lib32z1 \
@@ -202,6 +199,7 @@ RUN export DEBIAN_FRONTEND=noninteractive \
   libtinfo5:i386 \
   libcurl3-gnutls:i386 \
   libssl3:i386 \
+  libglib2.0-0 \
   ca-certificates \
   wget \
   unzip \
@@ -229,12 +227,17 @@ WORKDIR $HOME
 COPY ./variants/base/maps_to_keep ./variants/base/tf2.txt.template ./tf2version.txt $HOME/
 COPY --chmod=755 ./variants/base/install_tf2.sh $HOME/
 RUN envsubst < $HOME/tf2.txt.template > $HOME/tf2.txt \
-  && steamcmd +help +quit \
   && $HOME/install_tf2.sh \
   && find $SERVER_DIR/tf/maps -type f | grep -v "$(cat maps_to_keep)" | xargs rm -rf \
   && rm maps_to_keep \
   && mkdir -p $HOME/.steam \
-  && ln -s $HOME/.local/share/Steam/steamcmd/linux32 $HOME/.steam/sdk32
+  && ln -s $HOME/.local/share/Steam/steamcmd/linux32 $HOME/.steam/sdk32 \
+  && ln -s $HOME/.local/share/Steam/steamcmd $HOME/.steam/steamcmd
+
+RUN find $SERVER_DIR/hl2 $SERVER_DIR/tf -maxdepth 1 -name '*.sound.cache' -delete \
+  && rm -rf $HOME/.local/share/Steam/steamcmd/linux64 \
+    $HOME/.local/share/Steam/steamcmd/siteserverui \
+    $HOME/tf2version.txt
 
 COPY ./variants/base/tf/cfg/server.cfg.template ${SERVER_DIR}/tf/cfg/server.cfg.template
 COPY ./variants/base/rcon ${SERVER_DIR}/rcon
@@ -306,6 +309,9 @@ COPY --chown=tf2 variants/base/custom_entrypoint.sh .
 # Must be owned by root and run as root
 USER root
 COPY --chmod=755 variants/base/root_entrypoint.sh .
+
+# Prune fat that is not needed at runtime (TF2 install and autoupdate run as tf2)
+RUN rm -rf /root/.local/share/Steam /root/.steam
 
 ENTRYPOINT [ "./root_entrypoint.sh" ]
 CMD ["+sv_pure", "1", "+map", "cp_badlands", "+maxplayers", "24"]


### PR DESCRIPTION
## Summary

Shrinks `fat-standard-competitive-i386` without touching TF2 maps, plugins or configs, and adds a CI/local gate so an oversized image can never be pushed again.

## Why

OCI Container Instances provide a fixed 15 GB ephemeral storage shared between the image and the container's writable overlay, and Oracle recommends keeping the image under 7.5 GB so pull/unpack has headroom (#116). Before this change the extracted rootfs was 8.93 GB and growing.

## What changed

### Image fat pruning (`variants/fat-standard-competitive-i386/Dockerfile`)

- Drop `software-properties-common` and `add-apt-repository multiverse`. The `steamcmd/steamcmd:ubuntu-22` base already enables multiverse.
- Install `libglib2.0-0` directly. It was only a transitive dep of the removed package, and the `rcon` binary needs it at runtime (health check catches this).
- Remove the duplicate steamcmd under `/root` and unused `linux64` / `siteserverui` steamcmd parts. The TF2 install and srcds `-autoupdate` run as the `tf2` user.
- Delete regenerated `*.sound.cache` files and the `tf2version.txt` staging copy.
- Symlink `~/.steam/steamcmd` so `srcds_run -steam_dir $HOME/.steam/steamcmd -autoupdate` can actually locate steamcmd (the path did not exist before), keeping `linux32` + `package` in place for updates.

### Size gate (CI)

- New `packages/scripts/check_image_size.sh`: measures the true extracted rootfs (`docker export | wc -c`) and the stored image size (`docker image inspect .Size`), fails above a 14 GB default (1 GB runtime headroom under the 15 GB cap). Override with `OCI_MAX_IMAGE_SIZE_GB` or the second positional argument.
- Wired into `build-variant.yaml` between build and the health test, so every variant push is checked.
- Exposed locally via `npm run test:image-size`; documented in `variants/README.md`.

## Validation

Full local build with all 115 maps:

| Check | Result |
|---|---|
| `npm run build:fat:standard-competitive-i386` | OK |
| Size check | 7.89 GB extracted / 4.60 GB stored, under 14 GB limit |
| `test_image.sh` (cp_badlands, health check) | Container is healthy |

No maps, SourceMod plugins, leader configs, or enforced cvars were removed.
